### PR TITLE
fix: correct deeppresenter server path in mcp.json.example

### DIFF
--- a/deeppresenter/deeppresenter/mcp.json.example
+++ b/deeppresenter/deeppresenter/mcp.json.example
@@ -3,7 +3,7 @@
     "name": "deeppresenter",
     "description": "DeepPresenter Tools",
     "command": "uv",
-    "args": ["run", "deeppresenter/tools/server.py", "$WORKSPACE"],
+    "args": ["run", "deeppresenter/deeppresenter/tools/server.py", "$WORKSPACE"],
     "env": {
       "MINERU_API_URL": "your_deployed_mineru_url_for_offline_mode",
       "MINERU_API_KEY": "your_mineru_api_key_for_online_mode",


### PR DESCRIPTION
## Problem
When running `python webui.py` from the project root directory, the deeppresenter MCP server fails to start.

**Error message:**
error: Failed to spawn: `deeppresenter/tools/server.py`                                                   
Caused by: No such file or directory (os error 2)

## Cause
The path in `mcp.json.example` is missing one level of `deeppresenter` directory. 

## Solution                                                                                                                                                                                        Change the path from `deeppresenter/tools/server.py` to `deeppresenter/deeppresenter/tools/server.py`. 