### PR TITLE
fix: add missing python-pptx dependency

### DIFF
--- a/deeppresenter/pyproject.toml
+++ b/deeppresenter/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "semanticscholar>=0.11.0",
     "tavily-python>=0.7.14",
     "trafilatura>=2.0.0",
+    "python-pptx>=0.6.21",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Problem
The deeppresenter MCP server fails to start due to a missing dependency:

from pptx import Presentation
ModuleNotFoundError: No module named 'pptx'
ERROR [deeppresenter-loop-xxx] Error connecting to server deeppresenter: Connection closed

## Solution
Add `python-pptx>=0.6.21` to `deeppresenter/pyproject.toml` dependencies.
