### PR TITLE
fix(download_file): convert WEBP images to PNG for python-pptx compat…

### DIFF
--- a/deeppresenter/deeppresenter/tools/fetch.py
+++ b/deeppresenter/deeppresenter/tools/fetch.py
@@ -108,8 +108,8 @@ async def download_file(url: str, output_path: str) -> str:
             with Image.open(output_path) as img:
                 width, height = img.size
                 # Convert WEBP to PNG
-                if img.format == 'WEBP':
-                    png_path = str(Path(output_path).with_suffix('.png'))
+                if img.format == "WEBP":
+                    png_path = str(Path(output_path).with_suffix(".png"))
                     img.save(png_path, format="PNG")
                     Path(output_path).unlink()
                     output_path = png_path


### PR DESCRIPTION
…ibility

## Describe your changes

Convert WEBP format images to PNG when downloading images

Fixes "unsupported image format" error caused by python-pptx not supporting WEBP format when calling generate_slide

## Issue ticket number and link

None

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] If it is a core feature, I have added thorough tests.
