### PR TITLE
Fix html2pptx rendering for containers, bullets, inline tags, and flex lists

### DIFF
--- a/deeppresenter/deeppresenter/html2pptx/html2pptx.js
+++ b/deeppresenter/deeppresenter/html2pptx/html2pptx.js
@@ -1578,8 +1578,13 @@ async function extractSlideData(page) {
         if (parent) {
           const parentDisplay = window.getComputedStyle(parent).display;
           if (isLayoutDisplay(parentDisplay)) {
-            const textAncestor = el.closest('p,h1,h2,h3,h4,h5,h6,li,ul,ol');
+            const textAncestor = el.closest('p,h1,h2,h3,h4,h5,h6');
             if (textAncestor) return;
+            const listAncestor = el.closest('li,ul,ol');
+            if (listAncestor) {
+              const listDisplay = window.getComputedStyle(listAncestor).display;
+              if (!isLayoutDisplay(listDisplay)) return;
+            }
             const rect = el.getBoundingClientRect();
             if (rect.width > 0 && rect.height > 0 && el.textContent.trim()) {
               const computed = window.getComputedStyle(el);


### PR DESCRIPTION
## Describe your changes
  - Fixed list extraction for inline bullet spans (e.g., span.bullet) and added sup/sub run support.
  - Rendered inline tag chips (e.g., .tool-tag spans) as shape+text to preserve backgrounds/borders.
  - Allowed flex-based list spans to render even when ul/li are flex containers.
## Issue ticket number and link
N/A
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
