### PR TITLE
fix: replace 3 bare excepts with except Exception

### DIFF
--- a/deeppresenter/deeppresenter/tools/any2markdown.py
+++ b/deeppresenter/deeppresenter/tools/any2markdown.py
@@ -83,7 +83,7 @@ async def convert_to_markdown(file_path: str, output_folder: str) -> dict:
         try:
             with Image.open(img_path) as img:
                 images_with_info.append((img_path, *img.size))
-        except:
+        except Exception:
             continue
 
     images_with_info.sort(key=lambda x: int(x[1]), reverse=True)

--- a/deeppresenter/deeppresenter/tools/search.py
+++ b/deeppresenter/deeppresenter/tools/search.py
@@ -235,7 +235,7 @@ async def download_file(url: str, output_file: str) -> str:
                 with open(output_path, "wb") as f:
                     f.write(data)
             break
-        except:
+        except Exception:
             pass
     else:
         return f"Failed to download file from {url}"

--- a/deeppresenter/deeppresenter/utils/config.py
+++ b/deeppresenter/deeppresenter/utils/config.py
@@ -43,7 +43,7 @@ def get_json_from_response(response: str) -> dict | list:
     response = response.strip()
     try:
         return json.loads(response)
-    except:
+    except Exception:
         pass
 
     # Try to find JSON by looking for matching braces


### PR DESCRIPTION
Replace 3 bare `except:` with `except Exception:` across 3 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.