### PR TITLE
Fix Playwright browser installation and Docker CLI compatibility

### DIFF
--- a/deeppresenter/docker/Host.Dockerfile
+++ b/deeppresenter/docker/Host.Dockerfile
@@ -65,6 +65,9 @@ ENV PATH="/opt/.venv/bin:${PATH}" \
 RUN uv venv --python 3.13 $VIRTUAL_ENV && \
     uv pip install -e .
 
+# Install Python Playwright browser binaries used by deeppresenter runtime.
+RUN /opt/.venv/bin/playwright install chromium
+
 RUN apt install -y poppler-utils
 RUN apt install -y docker.io
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     volumes:
       - ./workspace:/opt/workspace
       - ./deeppresenter:/usr/src/pptagent/deeppresenter
+      - /usr/src/pptagent/deeppresenter/html2pptx/node_modules
       - /var/run/docker.sock:/var/run/docker.sock
+      - /usr/bin/docker:/usr/bin/docker:ro
       - $HOME/.cache/huggingface:/root/.cache/huggingface
 
 volumes:


### PR DESCRIPTION
## Describe your changes
- Install Python Playwright Chromium during `deeppresenter-host` image build (`/opt/.venv/bin/playwright install chromium`) so runtime no longer fails with missing executable / headless shell.
- Mount host `/usr/bin/docker` into the container as read-only so the in-container Docker CLI stays API-compatible with the host daemon when using `/var/run/docker.sock`, avoiding `client version too old`.
- Add an anonymous volume for `/usr/src/pptagent/deeppresenter/html2pptx/node_modules` so bind-mounting `./deeppresenter` does not shadow Node dependencies baked into the image, fixing `inspect_slide` “Node dependencies are missing”.

- **Why this change is needed**
  - Prevents runtime crashes in the Playwright-based conversion path (missing `chromium_headless_shell` / “Executable doesn't exist”).
  - Prevents Docker socket invocations from failing due to Docker CLI API version mismatch.
  - Ensures the `html2pptx` toolchain remains usable under the local compose development bind-mount workflow.

- **Scope / impact**
  - Container build/runtime wiring only (`Host.Dockerfile`, `docker-compose.yml`).
  - No application business logic changes.

- **How this was validated**
  - Rebuilt and started `deeppresenter-host` via docker compose.
  - Confirmed the service starts successfully and the previously failing Playwright/Docker invocation paths no longer throw the same errors.
  - Exercised the `html2pptx`/`inspect_slide` dependency path to confirm Node deps are available when `deeppresenter` is bind-mounted.

## Issue ticket number and link
- N/A (maintenance / reliability fix)
  <!-- Example: PROJ-123 https://... -->

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests. *(Not applicable: this is infra/container configuration; validation is done via rebuild + runtime checks.)*