### PR TITLE
feat(api): persist jobs and events in Supabase Postgres

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -1,0 +1,81 @@
+# GitHub Actions · Secrets checklist
+
+워크플로 4개가 정상 동작하려면 아래 시크릿이 **Repository → Settings → Secrets and variables → Actions** 에 등록돼야 합니다.
+
+## 한눈에 보기
+
+| Secret | 사용 워크플로 | 획득 방법 |
+|--------|--------------|-----------|
+| `VERCEL_TOKEN` | deploy-web | https://vercel.com/account/tokens |
+| `VERCEL_ORG_ID` | deploy-web | `vercel link` 후 `web/.vercel/project.json` → `orgId` |
+| `VERCEL_PROJECT_ID` | deploy-web | 동일 파일 → `projectId` |
+| `NEXT_PUBLIC_API_ORIGIN` | deploy-web | 예) `https://pptagent-api.fly.dev` |
+| `NEXT_PUBLIC_SUPABASE_URL` | deploy-web | Supabase 대시보드 → Settings → API |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | deploy-web | 동일 |
+| `FLY_API_TOKEN` | deploy-api | `fly auth token` (fly CLI) |
+| `SUPABASE_ACCESS_TOKEN` | deploy-supabase | https://supabase.com/dashboard/account/tokens |
+| `SUPABASE_PROJECT_REF` | deploy-supabase | 프로젝트 URL 의 8-char ref |
+| `GITHUB_TOKEN` | 모든 워크플로 | 자동 발급 (조치 불필요) |
+
+## Google API 키는 시크릿에 두지 않습니다
+
+Google Imagen/Gemini 키는 **Supabase Edge Function Secret** 에만 저장합니다. 이유:
+
+1. GitHub Actions 에 두면 로그/캐시/포크에 유출될 위험이 높아집니다.
+2. Edge Function 은 키를 런타임에만 프로세스에 주입하므로 버전 관리 기록에 남지 않습니다.
+3. 키 로테이션을 Supabase 대시보드에서 한 곳에서 처리할 수 있습니다.
+
+등록:
+
+```bash
+supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref <ref>
+```
+
+## gh CLI 로 한 번에 등록
+
+레포 루트에서:
+
+```bash
+# 1. 로그인 확인 (rkdghkclgns-design 계정)
+gh auth status
+
+# 2. .env.gh-secrets 파일을 만든 뒤 (커밋 절대 금지)
+cat > .env.gh-secrets <<'EOF'
+VERCEL_TOKEN=...
+VERCEL_ORG_ID=team_...
+VERCEL_PROJECT_ID=prj_...
+NEXT_PUBLIC_API_ORIGIN=https://pptagent-api.fly.dev
+NEXT_PUBLIC_SUPABASE_URL=https://xxxx.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
+FLY_API_TOKEN=fo1_...
+SUPABASE_ACCESS_TOKEN=sbp_...
+SUPABASE_PROJECT_REF=xxxx
+EOF
+
+# 3. 일괄 업로드 후 파일 삭제
+while IFS='=' read -r k v; do
+  [[ -z "$k" || "$k" =~ ^# ]] && continue
+  gh secret set "$k" --body "$v"
+done < .env.gh-secrets
+shred -u .env.gh-secrets 2>/dev/null || rm -f .env.gh-secrets
+```
+
+## Environments
+
+`deploy-web.yml` 와 `deploy-api.yml` 는 `production` · `preview` 환경을 참조합니다.
+GitHub 에서 **Settings → Environments → New environment** 로 두 개를 미리 만들어 두고,
+`production` 에는 required reviewer 를 지정하면 수동 승인 후 배포되도록 바꿀 수 있습니다.
+
+## PR 미리보기
+
+`deploy-web.yml` 은 PR 열릴 때 preview 배포 후 PR 바디에 URL 을 코멘트로 달아줍니다.
+`deploy-api.yml` 은 PR 에서는 이미지를 빌드만 하고 push/deploy 는 하지 않습니다.
+
+## 워크플로 발동 조건 요약
+
+| 워크플로 | 트리거 |
+|---------|-------|
+| `ci-web-api.yml` | `api/**`, `web/**`, `supabase/**` 가 포함된 PR/push |
+| `deploy-web.yml` | `web/**` push → 프로덕션, PR → 프리뷰, manual dispatch |
+| `deploy-api.yml` | `api/**`, `deeppresenter/**`, `pptagent/**` push → GHCR + Fly |
+| `deploy-supabase.yml` | `supabase/functions/**` push → Edge Function 재배포 |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,24 @@
+# GitHub Actions
+
+## Our workflows
+
+Added for the web-integration layer on top of `icip-cas/PPTAgent`:
+
+| File | What it does |
+|------|-------------|
+| `ci-web-api.yml` | Ruff + Mypy + import smoke test on `api/`, Next.js `tsc` + `build`, Deno `fmt`/`check` on `supabase/functions/llm-proxy` |
+| `deploy-web.yml` | PR → Vercel preview, push → Vercel prod. Posts preview URL back to the PR |
+| `deploy-api.yml` | Builds `api/Dockerfile` → GHCR (`ghcr.io/<owner>/pptagent-api`), then `flyctl deploy --image ghcr.io/<owner>/pptagent-api:latest` |
+| `deploy-supabase.yml` | `supabase functions deploy llm-proxy` with a `--dry-run` lint step before the real deploy |
+
+## Upstream workflows left untouched
+
+The original repo ships with `contributors.yml`, `docker-publish.yml`, and `pypi-publish.yml`.
+They are still in this repo and still fire on their original triggers. If you don't want
+them to run on your fork, disable them in **Actions → All workflows → Disable**.
+
+## Where to start
+
+1. Follow `.github/SECRETS.md` to register tokens.
+2. Push to `main` → watch the `Actions` tab.
+3. The first `deploy-api.yml` run can take ~8 minutes because it installs Playwright + the pptagent wheel inside the image; subsequent runs are cached (≈2 min).

--- a/.github/workflows/ci-web-api.yml
+++ b/.github/workflows/ci-web-api.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: |
           source .venv/bin/activate
-          ruff check api/ --target-version py312 --select E,F,W,I,UP
+          ruff check api/
 
       - name: Mypy (api/ only)
         shell: bash

--- a/.github/workflows/ci-web-api.yml
+++ b/.github/workflows/ci-web-api.yml
@@ -81,6 +81,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          # Keyed on package.json because we don't ship a lockfile yet. When
+          # we add web/package-lock.json, change this to the lockfile path.
           cache: npm
           cache-dependency-path: web/package.json
 

--- a/.github/workflows/ci-web-api.yml
+++ b/.github/workflows/ci-web-api.yml
@@ -1,0 +1,116 @@
+# CI for the web-integration layer we added on top of PPTAgent.
+#
+# Scope: only the api/, web/ and supabase/ folders. Upstream tests remain
+# untouched and keep running in their existing workflows.
+name: CI (web + api)
+
+on:
+  pull_request:
+    paths:
+      - "api/**"
+      - "web/**"
+      - "supabase/**"
+      - ".github/workflows/ci-web-api.yml"
+  push:
+    branches: [main]
+    paths:
+      - "api/**"
+      - "web/**"
+      - "supabase/**"
+      - ".github/workflows/ci-web-api.yml"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  api-typecheck:
+    name: FastAPI · import + lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install FastAPI wrapper deps (no playwright chromium)
+        shell: bash
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install -r api/requirements.txt ruff mypy
+
+      - name: Ruff lint
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          ruff check api/ --target-version py312 --select E,F,W,I,UP
+
+      - name: Mypy (api/ only)
+        shell: bash
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          mypy api/ --ignore-missing-imports --python-version 3.12 || true
+
+      - name: Import smoke test
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          python -c "
+          import importlib
+          for m in ['api.settings', 'api.schemas', 'api.routes.health', 'api.routes.models']:
+              importlib.import_module(m)
+              print('ok:', m)
+          "
+
+  web-typecheck:
+    name: Next.js · typecheck + build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package.json
+
+      - name: Install
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_API_ORIGIN: http://ci.local
+          NEXT_PUBLIC_SUPABASE_URL: https://ci.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-anon-key
+        run: npm run build
+
+  supabase-function-check:
+    name: Supabase · Deno check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Deno format (check only)
+        working-directory: supabase/functions/llm-proxy
+        run: deno fmt --check
+
+      - name: Deno check types
+        working-directory: supabase/functions/llm-proxy
+        run: deno check index.ts

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,127 @@
+# Build the FastAPI wrapper image, push to GHCR, then roll Fly.io.
+#
+# Secrets required:
+#   FLY_API_TOKEN          - `fly auth token`
+#
+# GHCR uses the built-in GITHUB_TOKEN with packages:write scope.
+# Image tag rules:
+#   - push to main          → ghcr.io/<owner>/pptagent-api:latest + sha-<short>
+#   - tag v*                → ghcr.io/<owner>/pptagent-api:<tag>
+#   - pull_request          → build only (no push, no deploy)
+name: Deploy API → GHCR + Fly.io
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    paths:
+      - "api/**"
+      - "deeppresenter/**"
+      - "pptagent/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/deploy-api.yml"
+      - "deploy/fly.toml"
+  pull_request:
+    paths:
+      - "api/**"
+      - ".github/workflows/deploy-api.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-api-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/pptagent-api
+
+jobs:
+  build-and-push:
+    name: Build image · push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build image (load into local runner for PRs)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: api/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-fly:
+    name: Release to Fly.io
+    needs: build-and-push
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl deploy \
+            --config deploy/fly.toml \
+            --image ghcr.io/${{ github.repository_owner }}/pptagent-api:latest \
+            --remote-only \
+            --strategy rolling \
+            --wait-timeout 300
+
+  smoke-test:
+    name: Post-deploy smoke test
+    needs: deploy-fly
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe /readiness
+        run: |
+          set -eu
+          for i in {1..12}; do
+            sleep 10
+            BODY=$(curl -fsSL https://pptagent-api.fly.dev/readiness || true)
+            echo "attempt $i: $BODY"
+            if echo "$BODY" | grep -q '"status"'; then
+              echo "ok"
+              exit 0
+            fi
+          done
+          echo "::warning title=Smoke test::api did not respond within 2m"
+          exit 1

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,90 @@
+# Deploy the Next.js studio to GitHub Pages as a static site.
+#
+# Why separate from deploy-web.yml?
+#   deploy-web.yml targets Vercel (preview + prod). GitHub Pages is an
+#   alternative, zero-cost host that serves the `next export` output. You can
+#   run both if you want redundancy.
+#
+# Public URL: https://rkdghkclgns-design.github.io/PPTAgent/
+#
+# Repo prerequisites (one-time):
+#   Settings → Pages → Source = "GitHub Actions"
+#   (screenshot state: already done ✅)
+#
+# Required secrets:
+#   NEXT_PUBLIC_API_ORIGIN          full URL of the FastAPI deployment
+#   NEXT_PUBLIC_SUPABASE_URL        https://<ref>.supabase.co
+#   NEXT_PUBLIC_SUPABASE_ANON_KEY   anon key (public - safe in the bundle)
+#
+# No Vercel tokens here - GitHub Pages uses GITHUB_TOKEN implicitly.
+name: Deploy web → GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build static site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package.json
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          static_site_generator: next
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build (static export)
+        env:
+          DEPLOY_TARGET: pages
+          NODE_ENV: production
+          NEXT_PUBLIC_API_ORIGIN: ${{ secrets.NEXT_PUBLIC_API_ORIGIN }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          npm run build
+          # GitHub Pages refuses `_next/*` paths unless we turn off Jekyll.
+          touch out/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/out
+
+  deploy:
+    name: Publish to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -1,0 +1,62 @@
+# Deploy Supabase Edge Function (llm-proxy) whenever the function code
+# or shared helpers change.
+#
+# Secrets required:
+#   SUPABASE_ACCESS_TOKEN      - https://supabase.com/dashboard/account/tokens
+#   SUPABASE_PROJECT_REF       - project ref (8-char)
+#   SUPABASE_DB_PASSWORD       - only needed for DB-migration steps (optional)
+#
+# The Google API key itself is NOT a GitHub secret - it's a Supabase secret
+# that was set once locally via `supabase secrets set GOOGLE_API_KEY=...`.
+# We intentionally avoid re-uploading it on every deploy to reduce blast radius.
+name: Deploy Supabase Edge Function
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/functions/**"
+      - "supabase/config.toml"
+      - ".github/workflows/deploy-supabase.yml"
+  workflow_dispatch:
+    inputs:
+      function:
+        type: choice
+        options: [llm-proxy]
+        default: llm-proxy
+        description: Function to deploy
+
+concurrency:
+  group: deploy-supabase
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: supabase functions deploy
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Lint function
+        run: supabase functions deploy --dry-run llm-proxy
+
+      - name: Deploy llm-proxy
+        run: supabase functions deploy llm-proxy --no-verify-jwt
+
+      - name: Verify health (OPTIONS)
+        run: |
+          URL="https://${SUPABASE_PROJECT_REF}.supabase.co/functions/v1/llm-proxy"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS "$URL")
+          echo "status=$STATUS"
+          [[ "$STATUS" == "200" || "$STATUS" == "204" ]]

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -52,7 +52,10 @@ jobs:
         run: supabase functions deploy --dry-run llm-proxy
 
       - name: Deploy llm-proxy
-        run: supabase functions deploy llm-proxy --no-verify-jwt
+        # JWT verification is ENABLED. Callers must present a valid Supabase
+        # anon or service-role token. Do not add --no-verify-jwt without a
+        # replacement auth scheme in place.
+        run: supabase functions deploy llm-proxy
 
       - name: Verify health (OPTIONS)
         run: |

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -13,15 +13,9 @@
 name: Deploy web → Vercel
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "web/**"
-      - ".github/workflows/deploy-web.yml"
-  pull_request:
-    paths:
-      - "web/**"
-      - ".github/workflows/deploy-web.yml"
+  # Deliberately manual-only. GitHub Pages (deploy-pages.yml) is the default
+  # frontend host; Vercel is available as a hot-swap backup you can invoke
+  # from the Actions tab or via `gh workflow run deploy-web.yml`.
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,98 @@
+# Deploy the Next.js studio to Vercel.
+#
+# Secrets required (Repo → Settings → Secrets and variables → Actions):
+#   VERCEL_TOKEN                   - vercel.com/account/tokens
+#   VERCEL_ORG_ID                  - vercel project .vercel/project.json
+#   VERCEL_PROJECT_ID              - vercel project .vercel/project.json
+#   NEXT_PUBLIC_API_ORIGIN         - public URL of the FastAPI deployment
+#   NEXT_PUBLIC_SUPABASE_URL       - supabase project URL
+#   NEXT_PUBLIC_SUPABASE_ANON_KEY  - supabase anon key (browser-safe)
+#
+# Two triggers: preview on PR, prod on push to main. Only fires when files
+# under web/ or this workflow change.
+name: Deploy web → Vercel
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-web.yml"
+  pull_request:
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-web.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Deployment target
+        options: [preview, production]
+        default: production
+
+concurrency:
+  group: deploy-web-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Vercel · ${{ github.event_name == 'push' && 'production' || (github.event.inputs.environment || 'preview') }}
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event_name == 'push' && 'production' || 'preview' }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel env
+        run: |
+          vercel pull --yes \
+            --environment=${{ github.event_name == 'push' && 'production' || 'preview' }} \
+            --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: web
+
+      - name: Write env overrides
+        working-directory: web
+        run: |
+          echo "NEXT_PUBLIC_API_ORIGIN=${{ secrets.NEXT_PUBLIC_API_ORIGIN }}" >> .env.production
+          echo "NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}" >> .env.production
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}" >> .env.production
+
+      - name: Build
+        working-directory: web
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+          else
+            vercel build --token=${{ secrets.VERCEL_TOKEN }}
+          fi
+
+      - name: Deploy
+        working-directory: web
+        id: deploy
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          else
+            URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "::notice title=Vercel URL::$URL"
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `🌐 **Studio preview**\n${{ steps.deploy.outputs.url }}`;
+            const { issue: { number }, repo: { owner, repo } } = context;
+            await github.rest.issues.createComment({ owner, repo, issue_number: number, body });

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -1,0 +1,109 @@
+# PPTAgent Web Integration
+
+> Korean-first integration layer that wraps `deeppresenter/` + `pptagent/` with a FastAPI backend, a Next.js 14 frontend (Dribbble-style), and a Supabase Edge Function that proxies all Google API calls.
+
+## 레이아웃
+
+```
+PPTAgent/
+├── deeppresenter/        # 원본 런타임 (수정 없음)
+├── pptagent/             # 원본 레거시 (수정 없음)
+├── api/                  # FastAPI 래퍼 → deeppresenter.main.AgentLoop 노출
+│   ├── main.py           # /health, /models, /generate (SSE), /generate/ws (WebSocket)
+│   ├── core/
+│   │   ├── bridge.py     # AgentLoop 호출 브리지
+│   │   ├── supabase.py   # Supabase Edge Function 호출
+│   │   └── storage.py    # PPTX 파일 Supabase Storage 업로드
+│   ├── routes/
+│   │   ├── generate.py
+│   │   ├── models.py
+│   │   └── health.py
+│   └── Dockerfile
+│
+├── web/                  # Next.js 14 App Router + Tailwind + shadcn/ui + Framer Motion
+│   ├── app/
+│   │   ├── page.tsx              # 랜딩
+│   │   ├── studio/page.tsx       # 3-pane 에디터
+│   │   ├── layout.tsx
+│   │   └── globals.css           # Dribbble-style design tokens
+│   ├── components/
+│   │   ├── studio/*              # Step Rail · Prompt · Preview · Model Selector · Progress
+│   │   └── common/*              # GlassCard · NoiseBackground · MotionButton
+│   └── lib/
+│       ├── api.ts                # FastAPI 클라이언트 (fetch + EventSource + WebSocket)
+│       ├── supabase.ts
+│       └── models.ts             # 모델 카탈로그 (기본값: google/imagen)
+│
+├── supabase/
+│   └── functions/
+│       └── llm-proxy/
+│           └── index.ts          # Deno Edge Function: 모델별 라우팅 (Gemini 텍스트/비전, Imagen T2I)
+│
+└── deploy/
+    ├── docker-compose.prod.yml
+    ├── railway.json
+    └── fly.toml
+```
+
+## 아키텍처
+
+```
+┌────────────────────┐   HTTPS    ┌─────────────────────┐  HTTPS   ┌────────────────────┐
+│  Next.js (Vercel)  │ ──REST──→  │  FastAPI (Railway)  │ ──call→  │ Supabase Edge Fn   │
+│  Dribbble UI       │ ──SSE/WS─→ │  AgentLoop wrapper  │ ←stream─ │ llm-proxy          │
+│  Model Selector    │            │  PPTX → Storage     │          │ Gemini / Imagen    │
+└────────────────────┘            └─────────────────────┘          └────────────────────┘
+                                           │
+                                           ▼
+                                  ┌──────────────────┐
+                                  │ Docker Sandbox   │
+                                  │ (deeppresenter-  │
+                                  │  sandbox 이미지)  │
+                                  └──────────────────┘
+```
+
+## 환경변수
+
+| 이름 | 설명 | 배치 위치 |
+|------|------|----------|
+| `SUPABASE_URL` | 프로젝트 URL | `api/` + `web/` |
+| `SUPABASE_ANON_KEY` | 클라이언트 anon 키 | `web/` |
+| `SUPABASE_SERVICE_ROLE_KEY` | 서버 service role 키 | `api/` |
+| `SUPABASE_EDGE_FUNCTION_URL` | llm-proxy 엔드포인트 | `api/` |
+| `GOOGLE_API_KEY` | Gemini/Imagen 공용 키 | **Supabase Edge Function Secrets 에만** |
+| `DEEPPRESENTER_WORKSPACE_BASE` | PPTX 임시 저장 경로 | `api/` |
+
+⚠️ **Google API 키는 프론트나 FastAPI에 절대 두지 말 것.** Supabase Edge Function Secrets 로만 주입하고, FastAPI 는 해당 Edge Function 에만 요청을 보냅니다.
+
+## 실행 순서 (로컬)
+
+```bash
+# 1. WSL2 Ubuntu 안에서
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv pip install -e .
+playwright install-deps && playwright install chromium
+npm install --prefix deeppresenter/html2pptx
+
+# 2. Docker Desktop (Windows) 가 실행 중일 것
+docker pull forceless/deeppresenter-sandbox
+docker tag forceless/deeppresenter-sandbox deeppresenter-sandbox
+
+# 3. Supabase Edge Function 배포
+supabase functions deploy llm-proxy --project-ref <YOUR_REF>
+supabase secrets set GOOGLE_API_KEY=<key> --project-ref <YOUR_REF>
+
+# 4. FastAPI 백엔드
+cd api && uv pip install -r requirements.txt && uvicorn main:app --reload --port 7870
+
+# 5. Next.js 프론트엔드
+cd web && pnpm install && pnpm dev  # http://localhost:3000
+```
+
+## 클라우드 배포
+
+- **프론트**: Vercel (web/ 서브디렉토리)
+- **백엔드**: Railway 또는 Fly.io (api/Dockerfile)
+- **Edge Function**: Supabase (supabase/functions/llm-proxy)
+- **스토리지**: Supabase Storage 의 `presentations` 버킷 (PPTX)
+
+자세한 배포는 [deploy/README.md](deploy/README.md) 참고.

--- a/SETUP_KO.md
+++ b/SETUP_KO.md
@@ -1,0 +1,217 @@
+# PPTAgent 웹 통합 셋업 가이드 (Windows / WSL2)
+
+> **현재 상태**: 클론 완료 · Docker Desktop 설치 완료 (재부팅/실행 필요) · WSL2 Ubuntu 준비됨 · api/web/supabase 통합 레이어 작성 완료.
+
+이 문서는 로컬에서 첫 PPT 가 만들어질 때까지의 **남은 수동 단계**만 다룹니다. 자동화가 가능한 부분은 이미 끝내뒀습니다.
+
+---
+
+## 0. 이미 완료된 것 (자동화 영역)
+
+| 항목 | 상태 |
+|------|------|
+| 레포 클론 | ✅ |
+| Docker Desktop 설치 (winget) | ✅ (Windows 재시작/실행 필요) |
+| WSL2 Ubuntu 24.04 | ✅ |
+| uv 설치 (WSL) | ✅ |
+| FastAPI 래퍼 (`api/`) | ✅ |
+| Next.js 프론트엔드 (`web/`) | ✅ |
+| Supabase Edge Function (`supabase/functions/llm-proxy/`) | ✅ |
+| Dribbble-style 디자인 시스템 | ✅ |
+| 배포 설정 (Docker Compose, Railway, Fly.io) | ✅ |
+
+---
+
+## 1. Docker Desktop 실행
+
+Docker Desktop 이 `winget` 으로 설치되었습니다. 지금:
+
+1. Windows 시작메뉴에서 **Docker Desktop** 실행
+2. 최초 실행 시 "WSL 2 integration" 동의
+3. Settings → Resources → WSL Integration 에서 **Ubuntu** 토글 ON
+4. 트레이 아이콘이 녹색이 될 때까지 대기 (2~3분)
+
+확인:
+
+```powershell
+docker --version
+wsl -d Ubuntu -- docker ps
+```
+
+---
+
+## 2. WSL2 안에서 시스템 의존성
+
+WSL 세션을 열고 다음을 한 번만 실행:
+
+```bash
+# WSL Ubuntu 셸
+sudo apt update
+sudo apt install -y build-essential python3-dev python3.12-venv \
+                    libxml2-dev libxslt1-dev libmagic1 poppler-utils \
+                    fonts-noto-cjk curl git
+```
+
+Node.js (WSL 쪽에는 없음):
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+
+---
+
+## 3. PPTAgent 의존성 재설치
+
+`fasttext` 빌드를 위해 build-essential 이 먼저 있어야 합니다.
+
+```bash
+cd "/mnt/c/Users/KGA-유치훈/OneDrive/바탕 화면/유치훈/디벨로켓/PPTAgent"
+source .venv-wsl/bin/activate      # 이미 만들어져 있음
+
+uv pip install -e .                # 이번엔 fasttext 가 빌드됩니다
+uv pip install -r api/requirements.txt
+
+# Playwright + Chromium
+playwright install-deps
+playwright install chromium
+
+# html2pptx (Node)
+npm install --prefix deeppresenter/html2pptx
+
+# 언어 판별 모델
+uv pip install modelscope
+modelscope download forceless/fasttext-language-id
+```
+
+---
+
+## 4. Docker 샌드박스 이미지
+
+```bash
+# Docker Desktop 이 실행 중일 때 (WSL 통합 ON)
+docker pull forceless/deeppresenter-sandbox
+docker tag forceless/deeppresenter-sandbox deeppresenter-sandbox
+docker images | grep deeppresenter
+```
+
+---
+
+## 5. Supabase 엣지 펑션 배포
+
+Supabase CLI 가 없다면:
+
+```bash
+npm install -g supabase
+```
+
+기존 Supabase 프로젝트에 연결 + 배포:
+
+```bash
+cd "/mnt/c/Users/KGA-유치훈/OneDrive/바탕 화면/유치훈/디벨로켓/PPTAgent/supabase"
+
+supabase login                                         # 최초 1회
+supabase link --project-ref <YOUR_PROJECT_REF>
+supabase functions deploy llm-proxy --no-verify-jwt
+supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref <YOUR_PROJECT_REF>
+```
+
+`presentations` 버킷이 없다면 Supabase 대시보드 Storage 에서 **프라이빗** 으로 1 개만 생성.
+
+---
+
+## 6. 환경변수 파일 작성
+
+### api/.env
+
+```bash
+cp api/.env.example api/.env
+```
+
+채워야 할 값:
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_EDGE_FUNCTION_URL` = `https://<ref>.supabase.co/functions/v1/llm-proxy`
+
+### web/.env.local
+
+```bash
+cp web/.env.local.example web/.env.local
+```
+
+채워야 할 값:
+- `NEXT_PUBLIC_API_ORIGIN` = `http://localhost:7870`
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+---
+
+## 7. 로컬 실행 (2 개 터미널)
+
+### 터미널 A — FastAPI (WSL)
+
+```bash
+cd "/mnt/c/Users/KGA-유치훈/OneDrive/바탕 화면/유치훈/디벨로켓/PPTAgent"
+source .venv-wsl/bin/activate
+uvicorn api.main:app --reload --port 7870
+```
+
+헬스체크: http://localhost:7870/readiness → 모든 필드 `true`
+
+### 터미널 B — Next.js (Windows PowerShell 또는 WSL)
+
+```bash
+cd web
+npm install          # 최초 1회, 5분 정도 소요
+npm run dev
+```
+
+브라우저: http://localhost:3000 (랜딩) → http://localhost:3000/studio (에디터)
+
+---
+
+## 8. 동작 확인
+
+1. 랜딩에서 **Studio 시작** 클릭
+2. 프롬프트 입력: `"AI 스타트업 피치덱 10장, CTO 대상"`
+3. 우측 드롭다운에서 **이미지 생성 = Imagen 3.0 (Standard)**, **디자인 = Gemini 2.5 Pro** 확인 (기본값)
+4. **PPT 만들기** 클릭
+5. 좌측 Rail 이 Research → Design → Render → Export 로 진행
+6. 우측 프리뷰에 슬라이드 썸네일이 순차 표시
+7. 완료 시 우상단 **PPTX** 버튼으로 다운로드 (Supabase Storage 의 서명된 URL)
+
+---
+
+## 9. 클라우드 배포
+
+상세는 [deploy/README.md](deploy/README.md) 참고. 요약:
+
+| 컴포넌트 | 플랫폼 | 주 명령 |
+|---------|-------|--------|
+| 프론트 | Vercel | `cd web && vercel --prod` |
+| API    | Railway | `railway up` (루트에서) |
+| API (대안) | Fly.io | `fly launch --config deploy/fly.toml` |
+| Edge Fn | Supabase | 이미 5단계에서 완료 |
+| 풀스택 | 자체 서버 | `docker compose -f deploy/docker-compose.prod.yml up -d` |
+
+---
+
+## 10. 자주 막히는 지점
+
+| 증상 | 원인 | 해결 |
+|-----|------|-----|
+| `fasttext` wheel 빌드 실패 | `build-essential`, `python3.12-dev` 부재 | 2단계 재실행 |
+| `docker: command not found` (WSL) | Docker Desktop WSL 통합 미활성 | 1단계 Settings → Resources → WSL Integration |
+| Playwright `chromium-browser` 없음 | `--with-deps` 플래그 없이 설치 | `playwright install --with-deps chromium` |
+| FastAPI `readiness` 에 `deeppresenter_importable: false` | 3단계가 미완료 | `uv pip install -e .` 재시도 |
+| Edge Function 401 | JWT verify 활성, 서비스롤 키 불일치 | `--no-verify-jwt` 로 재배포 또는 키 재확인 |
+| 프론트 CORS 오류 | `CORS_ORIGINS` 에 URL 누락 | `api/.env` 의 `CORS_ORIGINS` 에 추가 |
+
+---
+
+## 11. 다음에 건드리면 좋은 것
+
+- `api/core/bridge.py` 의 `progress_hook` 을 `deeppresenter` 의 실제 이벤트 포인트에 연결 (현재는 래퍼 레벨 이벤트)
+- `web/components/studio/SlidePreview.tsx` 의 썸네일 grid 를 드래그로 재정렬
+- Supabase Edge Function 에 **레이트 리밋 + 캐싱** 추가 (같은 프롬프트 재요청 시 비용 절감)
+- OAuth (Google/GitHub) 를 Supabase Auth 로 추가해 Studio 를 보호

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,23 @@
+# FastAPI wrapper runtime config.
+# Copy to api/.env and fill in the blanks.
+
+# Supabase (required for model proxying + PPTX storage)
+SUPABASE_URL=https://REPLACE.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=eyJ...  # server-side only, never ship to browser
+SUPABASE_EDGE_FUNCTION_URL=https://REPLACE.supabase.co/functions/v1/llm-proxy
+SUPABASE_STORAGE_BUCKET=presentations
+
+# Runtime
+WORKSPACE_BASE=~/.cache/deeppresenter
+OFFLINE_MODE=false
+
+# Default model routing (frontend can override per-request)
+DEFAULT_T2I_MODEL=google/imagen-3.0-generate-002
+DEFAULT_CHAT_MODEL=google/gemini-2.0-flash
+DEFAULT_LONG_CONTEXT_MODEL=google/gemini-2.5-flash
+DEFAULT_VISION_MODEL=google/gemini-2.0-flash-vision
+DEFAULT_DESIGN_MODEL=google/gemini-2.5-pro
+
+# CORS
+CORS_ORIGINS=["http://localhost:3000"]
+MAX_UPLOAD_MB=50

--- a/api/.env.example
+++ b/api/.env.example
@@ -18,6 +18,11 @@ DEFAULT_LONG_CONTEXT_MODEL=google/gemini-2.5-flash
 DEFAULT_VISION_MODEL=google/gemini-2.0-flash-vision
 DEFAULT_DESIGN_MODEL=google/gemini-2.5-pro
 
-# CORS
-CORS_ORIGINS=["http://localhost:3000"]
+# Auth (production MUST keep this on)
+AUTH_ENABLED=true
+
+# CORS - include every frontend origin that will call this API
+CORS_ORIGINS=["http://localhost:3000","https://rkdghkclgns-design.github.io"]
+CORS_ALLOW_METHODS=["GET","POST","OPTIONS"]
+CORS_ALLOW_HEADERS=["authorization","content-type","x-requested-with"]
 MAX_UPLOAD_MB=50

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,11 @@
+.env
+.env.local
+.env.*.local
+__pycache__/
+*.pyc
+.venv/
+.venv-wsl/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+*.egg-info/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -29,8 +29,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+# uv - pinned to a specific release tag so supply-chain changes upstream
+# don't silently reshape the image. Bump intentionally; avoid :latest.
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /usr/local/bin/uv
 
 WORKDIR /app
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,54 @@
+# FastAPI wrapper image.
+#
+# Build context: repo root (we need the deeppresenter/ + pptagent/ packages)
+#   docker build -f api/Dockerfile -t pptagent-api .
+#
+# Runtime deps:
+#   * Playwright/Chromium - deeppresenter's webview uses it to rasterise slides
+#   * Node 20             - deeppresenter/html2pptx/ conversion helper
+#   * poppler-utils       - PDF rasterisation
+#
+# We do NOT ship Docker-in-Docker here. The /docker mount is expected to be
+# wired at container start time (docker-compose or Railway with DOCKER_HOST).
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PORT=7870 \
+    HOST=0.0.0.0 \
+    NODE_VERSION=20.x
+
+# System deps for Playwright / PDF / Node
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg git build-essential \
+        poppler-utils libmagic1 fonts-noto-cjk \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION} | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# --- Python deps ---------------------------------------------------------
+COPY pyproject.toml uv.lock README.md MANIFEST.in ./
+COPY api/requirements.txt api/requirements.txt
+COPY deeppresenter ./deeppresenter
+COPY pptagent ./pptagent
+
+RUN uv pip install --system -r api/requirements.txt \
+    && uv pip install --system -e . \
+    && python -m playwright install --with-deps chromium
+
+# --- Node deps for html2pptx ---------------------------------------------
+RUN npm install --prefix deeppresenter/html2pptx --omit=dev
+
+# --- App code ------------------------------------------------------------
+COPY api ./api
+
+EXPOSE 7870
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "7870"]

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,40 @@
+# PPTAgent FastAPI Wrapper
+
+원본 `deeppresenter/` 와 `pptagent/` 를 **수정하지 않고** 웹에서 호출할 수 있도록 얇은
+REST/SSE/WebSocket 레이어를 얹은 모듈입니다.
+
+## 요약
+
+- `main.py` — FastAPI 앱, 라우터 등록, CORS, lifespan
+- `settings.py` — pydantic-settings 기반 환경 로딩 (`api/.env`)
+- `schemas.py` — 요청/응답 Pydantic 스키마
+- `core/bridge.py` — `deeppresenter.main.AgentLoop` 를 감싸는 async bridge
+- `core/supabase.py` — Supabase Storage + Edge Function 클라이언트
+- `routes/health.py` — `/health`, `/readiness`
+- `routes/models.py` — `/models` (프론트 드롭다운 카탈로그)
+- `routes/generate.py` — `/generate` (POST), `/generate/{id}/events` (SSE), `/generate/ws/{id}` (WS), `/generate/attachment`
+
+## 로컬 실행
+
+WSL2 Ubuntu 내부에서:
+
+```bash
+cd "/mnt/c/Users/KGA-유치훈/OneDrive/바탕 화면/유치훈/디벨로켓/PPTAgent"
+source .venv-wsl/bin/activate
+cp api/.env.example api/.env  # 값 채우기
+uvicorn api.main:app --reload --port 7870
+```
+
+## 왜 원본을 수정하지 않았나
+
+`deeppresenter` 는 자체적으로 `config.yaml` 을 읽어 OpenAI-호환 클라이언트를 만듭니다. 우리는
+그 `base_url` 을 Supabase Edge Function 주소로 주입하기만 하면 됩니다. 이 방식의 장점:
+
+1. 원본 업스트림을 `git pull` 할 때 충돌이 없습니다.
+2. Google API 키를 파이썬 프로세스가 보지 않으므로 보안이 강화됩니다.
+3. Edge Function 쪽에서 모델 라우팅/속도제한/로깅을 독립적으로 개선할 수 있습니다.
+
+## Google Imagen 기본값
+
+`Settings.default_t2i_model = "google/imagen-3.0-generate-002"` 로 고정돼 있고, 프론트에서
+요청 바디의 `models.t2i_model` 만 바꾸면 즉시 다른 Google 모델로 교체됩니다.

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,6 @@
+"""FastAPI wrapper around the DeepPresenter / PPTAgent runtime."""
+
+from .main import app, create_app
+
+__version__ = "0.1.0"
+__all__ = ["app", "create_app"]

--- a/api/core/__init__.py
+++ b/api/core/__init__.py
@@ -1,0 +1,13 @@
+"""Core bridge and Supabase helpers for the FastAPI wrapper."""
+
+from .bridge import AgentBridge, BridgeError, Job, build_runtime_config
+from .supabase import EdgeFunctionClient, StorageClient
+
+__all__ = [
+    "AgentBridge",
+    "BridgeError",
+    "EdgeFunctionClient",
+    "Job",
+    "StorageClient",
+    "build_runtime_config",
+]

--- a/api/core/__init__.py
+++ b/api/core/__init__.py
@@ -1,6 +1,7 @@
 """Core bridge and Supabase helpers for the FastAPI wrapper."""
 
 from .bridge import AgentBridge, BridgeError, Job, build_runtime_config
+from .jobs_repo import JobsRepo
 from .supabase import EdgeFunctionClient, StorageClient
 
 __all__ = [
@@ -8,6 +9,7 @@ __all__ = [
     "BridgeError",
     "EdgeFunctionClient",
     "Job",
+    "JobsRepo",
     "StorageClient",
     "build_runtime_config",
 ]

--- a/api/core/bridge.py
+++ b/api/core/bridge.py
@@ -162,7 +162,6 @@ def _message_to_event(job_id: str, msg: Any, *, stage: str = "log") -> GenerateE
     install).
     """
     text = getattr(msg, "text", None)
-    role = getattr(getattr(msg, "role", None), "value", None) or "system"
     if text is None:
         text = str(msg)
     resolved_stage = _infer_stage(text, stage)

--- a/api/core/bridge.py
+++ b/api/core/bridge.py
@@ -2,17 +2,18 @@
 
 Design notes:
 
-* We do NOT mutate anything inside `deeppresenter/`. Instead we build a
-  runtime config object whose base_url points at our Supabase Edge Function.
-  The OpenAI-compatible client inside `deeppresenter` then happily sends every
-  chat/image request to Supabase, which proxies to Google.
-* AgentLoop is heavy and synchronous. We run it inside `asyncio.to_thread` and
-  use an `asyncio.Queue` to surface progress events back to the HTTP/WebSocket
-  layer. Stage boundaries are detected by subscribing to deeppresenter's
-  logging hooks where available and falling back to polling the workspace dir.
-* The wrapper is import-guarded: if `deeppresenter` fails to import (missing
-  extras), the API still serves `/health` and `/models` so the frontend can
-  render.
+* We do NOT mutate anything inside `deeppresenter/`. A `DeepPresenterConfig`
+  is built at runtime pointing every `LLM.base_url` at the Supabase Edge
+  Function, so the Google API key never hits this process.
+* `AgentLoop.run()` is an `AsyncGenerator[str | ChatMessage, None]` - intermediate
+  yields are `ChatMessage` instances, the final yield is the PPTX path.
+  We consume it via `async for` and map each `ChatMessage` onto a streamed
+  `GenerateEvent`.
+* Jobs are kept in-memory with a TTL sweeper. A late-subscribing SSE client
+  gets the terminal event replayed so races between `POST /generate` and
+  `GET /generate/{id}/events` do not lose the final URL.
+* Paths from the client (`attachments`, `output_name`) are sanitized before
+  they are ever handed to the untrusted filesystem-touching upstream code.
 """
 
 from __future__ import annotations
@@ -20,11 +21,12 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, AsyncIterator, Callable
+from pathlib import Path, PurePosixPath
+from typing import Any, AsyncIterator
 
 from ..schemas import GenerateEvent, GenerateRequest
 from ..settings import Settings, get_settings
@@ -32,27 +34,74 @@ from .supabase import StorageClient
 
 logger = logging.getLogger("api.bridge")
 
+# Keep terminal jobs around this long so reconnecting SSE clients can replay
+# the final event instead of hanging forever on a drained queue.
+_TERMINAL_JOB_TTL_SECONDS = 60 * 60  # 1h
+
 
 # ---------------------------------------------------------------------------
 # Runtime config assembly
 # ---------------------------------------------------------------------------
 
-def build_runtime_config(req: GenerateRequest, settings: Settings) -> dict[str, Any]:
-    """Produce the dict that deeppresenter's config loader would normally read.
+def _sanitize_filename(name: str, default: str = "presentation.pptx") -> str:
+    """Return a filename safe to concatenate into a storage path.
 
-    Every model section points at the Supabase Edge Function, so the API key
-    used by the underlying OpenAI client is the Supabase service-role JWT.
-    The *actual* Google API key never leaves Supabase.
+    Strips directory components, replaces anything outside the allowlist,
+    and enforces a maximum length. Rejects empty results.
+    """
+    if not name:
+        return default
+    # `PurePosixPath.name` handles both "../foo" and "C:\\bar" by taking the
+    # final component.
+    bare = PurePosixPath(name.replace("\\", "/")).name or default
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", bare)[:120]
+    return safe or default
+
+
+def _sanitize_attachment_ref(ref: str) -> str:
+    """Accept only `uploads/<segment>` style references from the client.
+
+    The client is expected to upload attachments through `/generate/attachment`,
+    which returns a relative object path under `uploads/`. We refuse anything
+    else to stop the client from forcing the bridge to read `/etc/passwd`.
+    """
+    if not ref:
+        raise ValueError("empty attachment reference")
+    clean = ref.replace("\\", "/").lstrip("/")
+    parts = PurePosixPath(clean).parts
+    if not parts or parts[0] not in ("uploads", "demo"):
+        raise ValueError(f"attachment reference {ref!r} is not under uploads/")
+    if any(p in ("..", "") for p in parts):
+        raise ValueError(f"attachment reference {ref!r} contains a traversal segment")
+    return str(PurePosixPath(*parts))
+
+
+def build_runtime_config(
+    req: GenerateRequest,
+    settings: Settings,
+    workspace: Path,
+) -> dict[str, Any]:
+    """Produce the dict that `DeepPresenterConfig.model_validate` expects.
+
+    Every LLM section points at the Supabase Edge Function, so the OpenAI
+    client inside deeppresenter authenticates as the Supabase service-role
+    JWT and the real Google key stays out of this process.
     """
     edge_url = settings.supabase_edge_function_url.rstrip("/")
     base_url = edge_url or "http://localhost:54321/functions/v1/llm-proxy"
-    api_key = settings.supabase_service_role_key or "anon"
+    api_key = settings.supabase_service_role_key
+    if not api_key:
+        # Fail loudly rather than silently using a fake token.
+        raise RuntimeError("SUPABASE_SERVICE_ROLE_KEY is not configured")
 
     def section(model_id: str) -> dict[str, Any]:
         return {"base_url": base_url, "model": model_id, "api_key": api_key}
 
     m = req.models
     cfg: dict[str, Any] = {
+        # `file_path` is required by DeepPresenterConfig even though we load the
+        # config from memory; point it at a sentinel inside the workspace.
+        "file_path": str(workspace / "runtime-config.yaml"),
         "offline_mode": settings.offline_mode,
         "context_folding": True,
         "research_agent": section(m.research_agent or settings.default_chat_model),
@@ -69,7 +118,7 @@ def build_runtime_config(req: GenerateRequest, settings: Settings) -> dict[str, 
 
 
 # ---------------------------------------------------------------------------
-# Job orchestration
+# Job bookkeeping
 # ---------------------------------------------------------------------------
 
 @dataclass
@@ -81,26 +130,91 @@ class Job:
     task: asyncio.Task | None = None
     status: str = "queued"
     created_at: float = field(default_factory=time.time)
+    finished_at: float | None = None
+    # Replay buffer so late subscribers see the whole stream.
+    history: list[GenerateEvent] = field(default_factory=list)
 
 
 class BridgeError(RuntimeError):
     """Raised when the PPTAgent runtime is unavailable."""
 
 
+# ---------------------------------------------------------------------------
+# ChatMessage → GenerateEvent mapping
+# ---------------------------------------------------------------------------
+
+def _infer_stage(text: str, default: str) -> str:
+    t = text.lower()
+    if "research" in t or "manuscript" in t or "outline" in t:
+        return "research"
+    if "design" in t or "slide" in t or "html" in t:
+        return "design"
+    if "pptx" in t or "html2pptx" in t or "convert" in t:
+        return "render"
+    return default
+
+
+def _message_to_event(job_id: str, msg: Any, *, stage: str = "log") -> GenerateEvent:
+    """Best-effort translation of a deeppresenter ChatMessage into our schema.
+
+    We don't import ChatMessage directly to keep this file importable without
+    deeppresenter at hand (so `/health` and `/models` still work on a clean
+    install).
+    """
+    text = getattr(msg, "text", None)
+    role = getattr(getattr(msg, "role", None), "value", None) or "system"
+    if text is None:
+        text = str(msg)
+    resolved_stage = _infer_stage(text, stage)
+    return GenerateEvent(
+        job_id=job_id,
+        stage=resolved_stage,  # type: ignore[arg-type]
+        message=text[:400],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bridge
+# ---------------------------------------------------------------------------
+
 class AgentBridge:
-    """Owns live jobs and drives deeppresenter.main.AgentLoop."""
+    """Owns live jobs and drives `deeppresenter.main.AgentLoop`."""
 
     def __init__(self, settings: Settings | None = None) -> None:
         self.settings = settings or get_settings()
         self._jobs: dict[str, Job] = {}
         self._storage = StorageClient(self.settings)
+        self._sweeper_task: asyncio.Task | None = None
+
+    async def start_background_tasks(self) -> None:
+        if self._sweeper_task is None or self._sweeper_task.done():
+            self._sweeper_task = asyncio.create_task(self._ttl_sweeper(), name="ttl-sweeper")
+
+    async def _ttl_sweeper(self) -> None:
+        """Evict terminal jobs older than TTL so memory doesn't grow forever."""
+        while True:
+            try:
+                await asyncio.sleep(300)
+                cutoff = time.time() - _TERMINAL_JOB_TTL_SECONDS
+                drop = [
+                    jid for jid, j in self._jobs.items()
+                    if j.finished_at is not None and j.finished_at < cutoff
+                ]
+                for jid in drop:
+                    self._jobs.pop(jid, None)
+                if drop:
+                    logger.info("evicted %d terminal jobs", len(drop))
+            except asyncio.CancelledError:
+                return
+            except Exception:  # noqa: BLE001 - sweeper must never die
+                logger.exception("sweeper iteration failed")
 
     # ------------------------------------------------------------------
-    # Lifecycle
+    # Job lifecycle
     # ------------------------------------------------------------------
 
     def start(self, request: GenerateRequest) -> Job:
-        job_id = uuid.uuid4().hex[:12]
+        job_id = uuid.uuid4().hex
         workspace = self.settings.workspace_base / job_id
         workspace.mkdir(parents=True, exist_ok=True)
         job = Job(job_id=job_id, request=request, workspace=workspace)
@@ -112,24 +226,36 @@ class AgentBridge:
         return self._jobs.get(job_id)
 
     # ------------------------------------------------------------------
-    # Event streaming
+    # Event streaming with replay
     # ------------------------------------------------------------------
 
     async def events(self, job_id: str) -> AsyncIterator[GenerateEvent]:
         job = self._jobs.get(job_id)
         if not job:
             return
+        # Replay everything the job has already emitted.
+        for ev in list(job.history):
+            yield ev
+            if ev.stage in ("done", "error"):
+                return
         while True:
-            ev = await job.queue.get()
+            try:
+                ev = await asyncio.wait_for(job.queue.get(), timeout=300)
+            except asyncio.TimeoutError:
+                # Send a keepalive-ish log event so intermediaries don't kill
+                # the SSE socket during a long silent deeppresenter phase.
+                yield GenerateEvent(job_id=job_id, stage="log", message="(heartbeat)")
+                continue
             yield ev
             if ev.stage in ("done", "error"):
                 break
 
     async def _emit(self, job: Job, ev: GenerateEvent) -> None:
+        job.history.append(ev)
         await job.queue.put(ev)
 
     # ------------------------------------------------------------------
-    # Actual work
+    # Execution
     # ------------------------------------------------------------------
 
     async def _run(self, job: Job) -> None:
@@ -139,28 +265,76 @@ class AgentBridge:
                 job,
                 GenerateEvent(job_id=job.job_id, stage="log", message="job queued"),
             )
-            config = build_runtime_config(job.request, self.settings)
 
-            loop = asyncio.get_running_loop()
-
-            def progress_hook(stage: str, message: str, percent: float | None = None) -> None:
-                ev = GenerateEvent(
-                    job_id=job.job_id,
-                    stage=stage,  # type: ignore[arg-type]
-                    message=message,
-                    percent=percent,
+            try:
+                from deeppresenter.main import AgentLoop  # type: ignore
+                from deeppresenter.utils.config import DeepPresenterConfig  # type: ignore
+                from deeppresenter.utils.typings import (  # type: ignore
+                    ConvertType,
+                    InputRequest,
                 )
-                loop.call_soon_threadsafe(job.queue.put_nowait, ev)
+            except Exception as exc:  # pragma: no cover - surfaced to client
+                raise BridgeError(
+                    "deeppresenter is not importable. Install with "
+                    "`uv pip install -e .` inside WSL2 and ensure Docker "
+                    "Desktop is running."
+                ) from exc
 
-            pptx_path = await asyncio.to_thread(
-                _run_agent_loop_sync,
-                job=job,
-                config=config,
-                progress_hook=progress_hook,
+            config_dict = build_runtime_config(job.request, self.settings, job.workspace)
+            config = DeepPresenterConfig.model_validate(config_dict)
+
+            # Sanitize every attachment path - the upstream layer will copy
+            # these files into the workspace, so a traversal would let a
+            # client read arbitrary files off the FastAPI host.
+            try:
+                clean_attachments = [
+                    _sanitize_attachment_ref(p) for p in job.request.attachments
+                ]
+            except ValueError as exc:
+                raise BridgeError(str(exc)) from exc
+            # Resolve to absolute filesystem paths under the workspace.
+            resolved = [str((job.workspace / rel).resolve()) for rel in clean_attachments]
+
+            request = InputRequest(
+                instruction=job.request.prompt,
+                attachments=resolved,
+                num_pages=job.request.pages,
+                convert_type=ConvertType.PPTAGENT,
             )
 
-            # Upload to Supabase Storage and emit signed URL
-            object_path = f"{job.job_id}/{job.request.output_name}"
+            loop_impl = AgentLoop(
+                config=config,
+                session_id=job.job_id[:8],
+                workspace=job.workspace,
+                language="ko",
+            )
+
+            await self._emit(
+                job,
+                GenerateEvent(
+                    job_id=job.job_id,
+                    stage="research",
+                    message="AgentLoop started",
+                    percent=0.05,
+                ),
+            )
+
+            final_path: Path | None = None
+            current_stage = "research"
+            async for msg in loop_impl.run(request):
+                if isinstance(msg, (str, Path)):
+                    final_path = Path(msg)
+                    break
+                ev = _message_to_event(job.job_id, msg, stage=current_stage)
+                current_stage = ev.stage  # advance
+                await self._emit(job, ev)
+
+            if final_path is None or not final_path.exists():
+                raise BridgeError("AgentLoop exited without producing a PPTX file")
+
+            # Upload and emit terminal event
+            safe_name = _sanitize_filename(job.request.output_name, "presentation.pptx")
+            object_path = f"{job.job_id}/{safe_name}"
             await self._emit(
                 job,
                 GenerateEvent(
@@ -171,7 +345,7 @@ class AgentBridge:
                 ),
             )
             await self._storage.upload_file(
-                pptx_path,
+                final_path,
                 object_path,
                 "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             )
@@ -191,60 +365,32 @@ class AgentBridge:
         except Exception as exc:  # noqa: BLE001 - surfaced to client
             logger.exception("job %s failed", job.job_id)
             job.status = "failed"
+            # Don't leak raw exception text; callers see a generic code, full
+            # detail is in the server log above.
+            safe_msg = (
+                str(exc)
+                if isinstance(exc, BridgeError)
+                else "generation failed - see server log"
+            )
             await self._emit(
                 job,
                 GenerateEvent(
                     job_id=job.job_id,
                     stage="error",
                     message="generation failed",
-                    error=str(exc),
+                    error=safe_msg,
                 ),
             )
+        finally:
+            job.finished_at = time.time()
 
     async def close(self) -> None:
-        for job in self._jobs.values():
+        if self._sweeper_task and not self._sweeper_task.done():
+            self._sweeper_task.cancel()
+            with contextlib.suppress(Exception):
+                await self._sweeper_task
+        for job in list(self._jobs.values()):
             if job.task and not job.task.done():
                 job.task.cancel()
                 with contextlib.suppress(Exception):
                     await job.task
-
-
-# ---------------------------------------------------------------------------
-# Sync entrypoint that actually drives deeppresenter
-# ---------------------------------------------------------------------------
-
-def _run_agent_loop_sync(
-    *,
-    job: Job,
-    config: dict[str, Any],
-    progress_hook: Callable[[str, str, float | None], None],
-) -> Path:
-    """Import deeppresenter lazily and execute a single run.
-
-    Kept in a regular function so `asyncio.to_thread` can own it. If the import
-    fails (e.g. the user hasn't installed the extras yet), we raise a
-    `BridgeError` that the async layer turns into a streamed error event.
-    """
-    try:
-        from deeppresenter.main import AgentLoop  # type: ignore
-        from deeppresenter.utils.config import RuntimeConfig  # type: ignore
-    except Exception as exc:  # pragma: no cover - surfaced to user
-        raise BridgeError(
-            "deeppresenter is not importable. Install with `uv pip install -e .` "
-            "inside WSL2 and ensure Docker Desktop is running."
-        ) from exc
-
-    progress_hook("research", "starting research phase", 0.05)
-
-    runtime_config = RuntimeConfig.model_validate(config)
-    loop = AgentLoop(
-        prompt=job.request.prompt,
-        attachments=[Path(p) for p in job.request.attachments],
-        pages=job.request.pages,
-        workspace=job.workspace,
-        config=runtime_config,
-        progress_hook=progress_hook,  # optional; deeppresenter falls back if unused
-    )
-    pptx_path = loop.run(output_name=job.request.output_name)
-    progress_hook("export", "finalising PPTX", 0.9)
-    return Path(pptx_path)

--- a/api/core/bridge.py
+++ b/api/core/bridge.py
@@ -1,0 +1,250 @@
+"""Async bridge between FastAPI and deeppresenter's AgentLoop.
+
+Design notes:
+
+* We do NOT mutate anything inside `deeppresenter/`. Instead we build a
+  runtime config object whose base_url points at our Supabase Edge Function.
+  The OpenAI-compatible client inside `deeppresenter` then happily sends every
+  chat/image request to Supabase, which proxies to Google.
+* AgentLoop is heavy and synchronous. We run it inside `asyncio.to_thread` and
+  use an `asyncio.Queue` to surface progress events back to the HTTP/WebSocket
+  layer. Stage boundaries are detected by subscribing to deeppresenter's
+  logging hooks where available and falling back to polling the workspace dir.
+* The wrapper is import-guarded: if `deeppresenter` fails to import (missing
+  extras), the API still serves `/health` and `/models` so the frontend can
+  render.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, AsyncIterator, Callable
+
+from ..schemas import GenerateEvent, GenerateRequest
+from ..settings import Settings, get_settings
+from .supabase import StorageClient
+
+logger = logging.getLogger("api.bridge")
+
+
+# ---------------------------------------------------------------------------
+# Runtime config assembly
+# ---------------------------------------------------------------------------
+
+def build_runtime_config(req: GenerateRequest, settings: Settings) -> dict[str, Any]:
+    """Produce the dict that deeppresenter's config loader would normally read.
+
+    Every model section points at the Supabase Edge Function, so the API key
+    used by the underlying OpenAI client is the Supabase service-role JWT.
+    The *actual* Google API key never leaves Supabase.
+    """
+    edge_url = settings.supabase_edge_function_url.rstrip("/")
+    base_url = edge_url or "http://localhost:54321/functions/v1/llm-proxy"
+    api_key = settings.supabase_service_role_key or "anon"
+
+    def section(model_id: str) -> dict[str, Any]:
+        return {"base_url": base_url, "model": model_id, "api_key": api_key}
+
+    m = req.models
+    cfg: dict[str, Any] = {
+        "offline_mode": settings.offline_mode,
+        "context_folding": True,
+        "research_agent": section(m.research_agent or settings.default_chat_model),
+        "design_agent": section(m.design_agent or settings.default_design_model),
+        "long_context_model": section(
+            m.long_context_model or settings.default_long_context_model
+        ),
+    }
+    if m.vision_model or settings.default_vision_model:
+        cfg["vision_model"] = section(m.vision_model or settings.default_vision_model)
+    if m.t2i_model or settings.default_t2i_model:
+        cfg["t2i_model"] = section(m.t2i_model or settings.default_t2i_model)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Job orchestration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Job:
+    job_id: str
+    request: GenerateRequest
+    workspace: Path
+    queue: asyncio.Queue[GenerateEvent] = field(default_factory=asyncio.Queue)
+    task: asyncio.Task | None = None
+    status: str = "queued"
+    created_at: float = field(default_factory=time.time)
+
+
+class BridgeError(RuntimeError):
+    """Raised when the PPTAgent runtime is unavailable."""
+
+
+class AgentBridge:
+    """Owns live jobs and drives deeppresenter.main.AgentLoop."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._jobs: dict[str, Job] = {}
+        self._storage = StorageClient(self.settings)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, request: GenerateRequest) -> Job:
+        job_id = uuid.uuid4().hex[:12]
+        workspace = self.settings.workspace_base / job_id
+        workspace.mkdir(parents=True, exist_ok=True)
+        job = Job(job_id=job_id, request=request, workspace=workspace)
+        self._jobs[job_id] = job
+        job.task = asyncio.create_task(self._run(job), name=f"agentloop:{job_id}")
+        return job
+
+    def get(self, job_id: str) -> Job | None:
+        return self._jobs.get(job_id)
+
+    # ------------------------------------------------------------------
+    # Event streaming
+    # ------------------------------------------------------------------
+
+    async def events(self, job_id: str) -> AsyncIterator[GenerateEvent]:
+        job = self._jobs.get(job_id)
+        if not job:
+            return
+        while True:
+            ev = await job.queue.get()
+            yield ev
+            if ev.stage in ("done", "error"):
+                break
+
+    async def _emit(self, job: Job, ev: GenerateEvent) -> None:
+        await job.queue.put(ev)
+
+    # ------------------------------------------------------------------
+    # Actual work
+    # ------------------------------------------------------------------
+
+    async def _run(self, job: Job) -> None:
+        try:
+            job.status = "running"
+            await self._emit(
+                job,
+                GenerateEvent(job_id=job.job_id, stage="log", message="job queued"),
+            )
+            config = build_runtime_config(job.request, self.settings)
+
+            loop = asyncio.get_running_loop()
+
+            def progress_hook(stage: str, message: str, percent: float | None = None) -> None:
+                ev = GenerateEvent(
+                    job_id=job.job_id,
+                    stage=stage,  # type: ignore[arg-type]
+                    message=message,
+                    percent=percent,
+                )
+                loop.call_soon_threadsafe(job.queue.put_nowait, ev)
+
+            pptx_path = await asyncio.to_thread(
+                _run_agent_loop_sync,
+                job=job,
+                config=config,
+                progress_hook=progress_hook,
+            )
+
+            # Upload to Supabase Storage and emit signed URL
+            object_path = f"{job.job_id}/{job.request.output_name}"
+            await self._emit(
+                job,
+                GenerateEvent(
+                    job_id=job.job_id,
+                    stage="upload",
+                    message="uploading PPTX to storage",
+                    percent=0.95,
+                ),
+            )
+            await self._storage.upload_file(
+                pptx_path,
+                object_path,
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            )
+            url = await self._storage.signed_url(object_path, expires_in=3600)
+
+            job.status = "succeeded"
+            await self._emit(
+                job,
+                GenerateEvent(
+                    job_id=job.job_id,
+                    stage="done",
+                    message="presentation ready",
+                    percent=1.0,
+                    pptx_url=url,
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced to client
+            logger.exception("job %s failed", job.job_id)
+            job.status = "failed"
+            await self._emit(
+                job,
+                GenerateEvent(
+                    job_id=job.job_id,
+                    stage="error",
+                    message="generation failed",
+                    error=str(exc),
+                ),
+            )
+
+    async def close(self) -> None:
+        for job in self._jobs.values():
+            if job.task and not job.task.done():
+                job.task.cancel()
+                with contextlib.suppress(Exception):
+                    await job.task
+
+
+# ---------------------------------------------------------------------------
+# Sync entrypoint that actually drives deeppresenter
+# ---------------------------------------------------------------------------
+
+def _run_agent_loop_sync(
+    *,
+    job: Job,
+    config: dict[str, Any],
+    progress_hook: Callable[[str, str, float | None], None],
+) -> Path:
+    """Import deeppresenter lazily and execute a single run.
+
+    Kept in a regular function so `asyncio.to_thread` can own it. If the import
+    fails (e.g. the user hasn't installed the extras yet), we raise a
+    `BridgeError` that the async layer turns into a streamed error event.
+    """
+    try:
+        from deeppresenter.main import AgentLoop  # type: ignore
+        from deeppresenter.utils.config import RuntimeConfig  # type: ignore
+    except Exception as exc:  # pragma: no cover - surfaced to user
+        raise BridgeError(
+            "deeppresenter is not importable. Install with `uv pip install -e .` "
+            "inside WSL2 and ensure Docker Desktop is running."
+        ) from exc
+
+    progress_hook("research", "starting research phase", 0.05)
+
+    runtime_config = RuntimeConfig.model_validate(config)
+    loop = AgentLoop(
+        prompt=job.request.prompt,
+        attachments=[Path(p) for p in job.request.attachments],
+        pages=job.request.pages,
+        workspace=job.workspace,
+        config=runtime_config,
+        progress_hook=progress_hook,  # optional; deeppresenter falls back if unused
+    )
+    pptx_path = loop.run(output_name=job.request.output_name)
+    progress_hook("export", "finalising PPTX", 0.9)
+    return Path(pptx_path)

--- a/api/core/bridge.py
+++ b/api/core/bridge.py
@@ -30,6 +30,7 @@ from typing import Any, AsyncIterator
 
 from ..schemas import GenerateEvent, GenerateRequest
 from ..settings import Settings, get_settings
+from .jobs_repo import JobsRepo
 from .supabase import StorageClient
 
 logger = logging.getLogger("api.bridge")
@@ -133,6 +134,8 @@ class Job:
     finished_at: float | None = None
     # Replay buffer so late subscribers see the whole stream.
     history: list[GenerateEvent] = field(default_factory=list)
+    # Monotonic sequence number for the Postgres job_events table.
+    event_seq: int = 0
 
 
 class BridgeError(RuntimeError):
@@ -183,6 +186,7 @@ class AgentBridge:
         self.settings = settings or get_settings()
         self._jobs: dict[str, Job] = {}
         self._storage = StorageClient(self.settings)
+        self._repo = JobsRepo(self.settings)
         self._sweeper_task: asyncio.Task | None = None
 
     async def start_background_tasks(self) -> None:
@@ -212,17 +216,41 @@ class AgentBridge:
     # Job lifecycle
     # ------------------------------------------------------------------
 
-    def start(self, request: GenerateRequest) -> Job:
+    def start(self, request: GenerateRequest, owner_sub: str | None = None) -> Job:
         job_id = uuid.uuid4().hex
         workspace = self.settings.workspace_base / job_id
         workspace.mkdir(parents=True, exist_ok=True)
         job = Job(job_id=job_id, request=request, workspace=workspace)
         self._jobs[job_id] = job
-        job.task = asyncio.create_task(self._run(job), name=f"agentloop:{job_id}")
+        job.task = asyncio.create_task(
+            self._run(job, owner_sub=owner_sub), name=f"agentloop:{job_id}"
+        )
         return job
 
     def get(self, job_id: str) -> Job | None:
         return self._jobs.get(job_id)
+
+    async def restore(self, job_id: str) -> Job | None:
+        """Hydrate an in-memory Job from Postgres.
+
+        Only useful when a previous machine handled `start()` and this one
+        is handling the SSE reconnect. Events are replayed from the DB.
+        """
+        if job_id in self._jobs:
+            return self._jobs[job_id]
+        rec = await self._repo.load_job(job_id)
+        if rec is None:
+            return None
+        workspace = self.settings.workspace_base / rec.id
+        job = Job(job_id=rec.id, request=rec.request, workspace=workspace)
+        job.status = rec.status
+        past = await self._repo.load_events(rec.id)
+        job.history.extend(past)
+        job.event_seq = len(past)
+        if rec.status in ("succeeded", "failed"):
+            job.finished_at = time.time()
+        self._jobs[job_id] = job
+        return job
 
     # ------------------------------------------------------------------
     # Event streaming with replay
@@ -251,15 +279,37 @@ class AgentBridge:
 
     async def _emit(self, job: Job, ev: GenerateEvent) -> None:
         job.history.append(ev)
+        job.event_seq += 1
         await job.queue.put(ev)
+        # Best-effort persistence - never block the pipeline on a DB hiccup.
+        try:
+            await self._repo.append_event(job.job_id, job.event_seq, ev)
+        except Exception:  # noqa: BLE001
+            logger.exception("failed to persist event seq=%d", job.event_seq)
 
     # ------------------------------------------------------------------
     # Execution
     # ------------------------------------------------------------------
 
-    async def _run(self, job: Job) -> None:
+    async def _run(self, job: Job, owner_sub: str | None = None) -> None:
         try:
+            # Persist the queued row first so the SSE endpoint can find it
+            # even if the machine dies before the first event is emitted.
+            try:
+                await self._repo.insert_job(
+                    job_id=job.job_id,
+                    request=job.request,
+                    workspace=str(job.workspace),
+                    owner_sub=owner_sub,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception("failed to persist job row")
+
             job.status = "running"
+            try:
+                await self._repo.mark_status(job.job_id, "running")
+            except Exception:  # noqa: BLE001
+                logger.exception("failed to mark job running")
             await self._emit(
                 job,
                 GenerateEvent(job_id=job.job_id, stage="log", message="job queued"),
@@ -351,6 +401,8 @@ class AgentBridge:
             url = await self._storage.signed_url(object_path, expires_in=3600)
 
             job.status = "succeeded"
+            with contextlib.suppress(Exception):
+                await self._repo.mark_status(job.job_id, "succeeded", pptx_url=url)
             await self._emit(
                 job,
                 GenerateEvent(
@@ -364,6 +416,10 @@ class AgentBridge:
         except Exception as exc:  # noqa: BLE001 - surfaced to client
             logger.exception("job %s failed", job.job_id)
             job.status = "failed"
+            with contextlib.suppress(Exception):
+                await self._repo.mark_status(
+                    job.job_id, "failed", error=str(exc)[:500]
+                )
             # Don't leak raw exception text; callers see a generic code, full
             # detail is in the server log above.
             safe_msg = (

--- a/api/core/jobs_repo.py
+++ b/api/core/jobs_repo.py
@@ -1,0 +1,199 @@
+"""Postgres-backed job + event repository.
+
+All persistence goes through the Supabase REST API (PostgREST) so we don't
+pin a psycopg dependency. The service-role key bypasses RLS so FastAPI can
+read and write any row.
+
+The repo is intentionally thin - it owns persistence only, not orchestration.
+`AgentBridge` still schedules work and translates ChatMessages; it just
+checkpoints each state transition here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from ..schemas import GenerateEvent, GenerateRequest
+from ..settings import Settings, get_settings
+
+logger = logging.getLogger("api.jobs_repo")
+
+_TERMINAL = ("succeeded", "failed")
+
+
+@dataclass(slots=True)
+class JobRecord:
+    id: str
+    status: str
+    request: GenerateRequest
+    workspace: str | None
+    owner_sub: str | None
+    pptx_url: str | None = None
+    error: str | None = None
+
+
+class JobsRepo:
+    """PostgREST client for the public.jobs and public.job_events tables."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._base = f"{self.settings.supabase_url.rstrip('/')}/rest/v1" if self.settings.supabase_url else ""
+        self._headers = {
+            "apikey": self.settings.supabase_service_role_key,
+            "Authorization": f"Bearer {self.settings.supabase_service_role_key}",
+            "content-type": "application/json",
+            "Prefer": "return=representation",
+        }
+
+    @property
+    def enabled(self) -> bool:
+        """Repo is a no-op when Supabase isn't configured (local dev)."""
+        return bool(self._base and self.settings.supabase_service_role_key)
+
+    # ------------------------------------------------------------------
+    # Jobs
+    # ------------------------------------------------------------------
+
+    async def insert_job(
+        self,
+        *,
+        job_id: str,
+        request: GenerateRequest,
+        workspace: str,
+        owner_sub: str | None,
+    ) -> None:
+        if not self.enabled:
+            return
+        payload = {
+            "id": job_id,
+            "status": "queued",
+            "prompt": request.prompt,
+            "pages": request.pages,
+            "output_name": request.output_name,
+            "models": request.models.model_dump(exclude_none=True),
+            "attachments": request.attachments,
+            "workspace": workspace,
+            "owner_sub": owner_sub,
+        }
+        await self._post("/jobs", payload)
+
+    async def mark_status(
+        self,
+        job_id: str,
+        status: str,
+        *,
+        pptx_url: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        if not self.enabled:
+            return
+        patch: dict[str, Any] = {"status": status}
+        if status == "running":
+            patch["started_at"] = "now()"
+        if status in _TERMINAL:
+            patch["finished_at"] = "now()"
+        if pptx_url is not None:
+            patch["pptx_url"] = pptx_url
+        if error is not None:
+            patch["error"] = error
+        await self._patch(f"/jobs?id=eq.{job_id}", patch)
+
+    async def load_job(self, job_id: str) -> JobRecord | None:
+        if not self.enabled:
+            return None
+        rows = await self._get(f"/jobs?id=eq.{job_id}&select=*&limit=1")
+        if not rows:
+            return None
+        row = rows[0]
+        req = GenerateRequest.model_validate(
+            {
+                "prompt": row["prompt"],
+                "pages": row.get("pages"),
+                "output_name": row.get("output_name", "presentation.pptx"),
+                "models": row.get("models") or {},
+                "attachments": row.get("attachments") or [],
+            }
+        )
+        return JobRecord(
+            id=row["id"],
+            status=row["status"],
+            request=req,
+            workspace=row.get("workspace"),
+            owner_sub=row.get("owner_sub"),
+            pptx_url=row.get("pptx_url"),
+            error=row.get("error"),
+        )
+
+    # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+
+    async def append_event(self, job_id: str, seq: int, event: GenerateEvent) -> None:
+        if not self.enabled:
+            return
+        payload = {
+            "job_id": job_id,
+            "seq": seq,
+            "stage": event.stage,
+            "message": event.message,
+            "percent": event.percent,
+            "slide_index": event.slide_index,
+            "slide_preview_url": event.slide_preview_url,
+            "pptx_url": event.pptx_url,
+            "error": event.error,
+        }
+        await self._post("/job_events", payload)
+
+    async def load_events(self, job_id: str, after_seq: int = 0) -> list[GenerateEvent]:
+        if not self.enabled:
+            return []
+        rows = await self._get(
+            f"/job_events?job_id=eq.{job_id}&seq=gt.{after_seq}&order=seq.asc&select=*"
+        )
+        out: list[GenerateEvent] = []
+        for row in rows:
+            out.append(
+                GenerateEvent(
+                    job_id=job_id,
+                    stage=row["stage"],
+                    message=row["message"],
+                    percent=row.get("percent"),
+                    slide_index=row.get("slide_index"),
+                    slide_preview_url=row.get("slide_preview_url"),
+                    pptx_url=row.get("pptx_url"),
+                    error=row.get("error"),
+                )
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Low-level HTTP
+    # ------------------------------------------------------------------
+
+    async def _post(self, path: str, body: Any) -> Any:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            res = await client.post(self._base + path, json=body, headers=self._headers)
+        if res.status_code >= 400:
+            logger.warning("jobs_repo POST %s failed: %s %s", path, res.status_code, res.text[:200])
+            res.raise_for_status()
+        return res.json() if res.content else None
+
+    async def _patch(self, path: str, body: Any) -> Any:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            res = await client.patch(self._base + path, json=body, headers=self._headers)
+        if res.status_code >= 400:
+            logger.warning("jobs_repo PATCH %s failed: %s %s", path, res.status_code, res.text[:200])
+            res.raise_for_status()
+        return res.json() if res.content else None
+
+    async def _get(self, path: str) -> list[Any]:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            res = await client.get(self._base + path, headers=self._headers)
+        if res.status_code >= 400:
+            logger.warning("jobs_repo GET %s failed: %s %s", path, res.status_code, res.text[:200])
+            res.raise_for_status()
+        return res.json() if res.content else []

--- a/api/core/supabase.py
+++ b/api/core/supabase.py
@@ -1,0 +1,98 @@
+"""Thin async wrappers around the Supabase REST + Edge Function surface.
+
+The FastAPI server does NOT hold a Google API key. When `deeppresenter/pptagent`
+makes an OpenAI-compatible call, it is pointed at `edge_function_url` and the
+service role JWT is attached so Supabase can verify the request. The Edge
+Function then fans out to Gemini or Imagen server-side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ..settings import Settings, get_settings
+
+
+@dataclass(slots=True)
+class EdgeResponse:
+    status_code: int
+    payload: dict[str, Any]
+
+
+class EdgeFunctionClient:
+    """Calls the llm-proxy Edge Function with an OpenAI-shaped body."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+
+    async def call(self, body: dict[str, Any]) -> EdgeResponse:
+        if not self.settings.supabase_edge_function_url:
+            raise RuntimeError("SUPABASE_EDGE_FUNCTION_URL is not set")
+        headers = {
+            "content-type": "application/json",
+            "Authorization": f"Bearer {self.settings.supabase_service_role_key}",
+            "apikey": self.settings.supabase_service_role_key,
+        }
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            res = await client.post(
+                self.settings.supabase_edge_function_url,
+                json=body,
+                headers=headers,
+            )
+        try:
+            payload = res.json()
+        except Exception:
+            payload = {"error": {"raw": res.text}}
+        return EdgeResponse(res.status_code, payload)
+
+
+class StorageClient:
+    """Minimal Supabase Storage client over HTTP.
+
+    We intentionally avoid the heavyweight `supabase-py` dependency on the hot
+    path - httpx is enough for upload/signed-url.
+    """
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._base = f"{self.settings.supabase_url}/storage/v1"
+
+    async def upload(self, object_path: str, data: bytes, content_type: str) -> str:
+        url = f"{self._base}/object/{self.settings.supabase_storage_bucket}/{object_path}"
+        headers = {
+            "Authorization": f"Bearer {self.settings.supabase_service_role_key}",
+            "apikey": self.settings.supabase_service_role_key,
+            "content-type": content_type,
+            "x-upsert": "true",
+        }
+        async with httpx.AsyncClient(timeout=300.0) as client:
+            res = await client.post(url, content=data, headers=headers)
+        res.raise_for_status()
+        return object_path
+
+    async def signed_url(self, object_path: str, expires_in: int = 3600) -> str:
+        url = f"{self._base}/object/sign/{self.settings.supabase_storage_bucket}/{object_path}"
+        headers = {
+            "Authorization": f"Bearer {self.settings.supabase_service_role_key}",
+            "apikey": self.settings.supabase_service_role_key,
+            "content-type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            res = await client.post(url, json={"expiresIn": expires_in}, headers=headers)
+        res.raise_for_status()
+        body = res.json()
+        signed = body.get("signedURL") or body.get("signedUrl")
+        if not signed:
+            raise RuntimeError(f"unexpected signed url response: {body}")
+        if signed.startswith("/"):
+            signed = f"{self.settings.supabase_url}/storage/v1{signed}"
+        return signed
+
+    async def upload_file(self, local_path: Path, object_path: str, content_type: str) -> str:
+        data = await asyncio.to_thread(local_path.read_bytes)
+        return await self.upload(object_path, data, content_type)

--- a/api/main.py
+++ b/api/main.py
@@ -32,10 +32,12 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     settings.workspace_base.mkdir(parents=True, exist_ok=True)
     app.state.bridge = AgentBridge(settings)
+    await app.state.bridge.start_background_tasks()
     logging.getLogger("api").info(
-        "FastAPI ready - workspace=%s edge_url=%s",
+        "FastAPI ready - workspace=%s edge_url=%s auth=%s",
         settings.workspace_base,
         settings.supabase_edge_function_url or "<unset>",
+        "on" if settings.auth_enabled else "OFF",
     )
     try:
         yield
@@ -59,8 +61,9 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=settings.cors_origins,
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=settings.cors_allow_methods,
+        allow_headers=settings.cors_allow_headers,
+        max_age=3600,
     )
     app.include_router(health.router)
     app.include_router(models.router)

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,71 @@
+"""FastAPI entrypoint.
+
+Run locally:
+    uv pip install -r api/requirements.txt
+    uvicorn api.main:app --reload --port 7870
+
+Run in Docker (Railway / Fly):
+    docker build -f api/Dockerfile -t pptagent-api .
+    docker run -p 7870:7870 --env-file .env pptagent-api
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .core import AgentBridge
+from .routes import generate, health, models
+from .settings import get_settings
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s | %(message)s",
+)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_settings()
+    settings.workspace_base.mkdir(parents=True, exist_ok=True)
+    app.state.bridge = AgentBridge(settings)
+    logging.getLogger("api").info(
+        "FastAPI ready - workspace=%s edge_url=%s",
+        settings.workspace_base,
+        settings.supabase_edge_function_url or "<unset>",
+    )
+    try:
+        yield
+    finally:
+        await app.state.bridge.close()
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    app = FastAPI(
+        title="PPTAgent Web API",
+        version="0.1.0",
+        description=(
+            "Thin wrapper around deeppresenter.main.AgentLoop. "
+            "All LLM calls flow through the Supabase llm-proxy Edge Function "
+            "so the Google API key never touches this server."
+        ),
+        lifespan=lifespan,
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(health.router)
+    app.include_router(models.router)
+    app.include_router(generate.router)
+    return app
+
+
+app = create_app()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -7,7 +7,9 @@ pydantic>=2.9,<3
 pydantic-settings>=2.6,<3
 python-multipart>=0.0.17,<1
 httpx>=0.28,<1
-supabase>=2.9,<3
+# supabase-py intentionally omitted - we use httpx directly against the
+# storage REST API in core/supabase.py. Re-add only if/when we need realtime
+# or gotrue client helpers.
 python-jose[cryptography]>=3.3,<4
 websockets>=13.1,<14
 sse-starlette>=2.1,<3

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,13 @@
+# FastAPI wrapper dependencies.
+# The PPTAgent core (deeppresenter/, pptagent/) is installed from the repo root
+# via `uv pip install -e ..` and provides everything else.
+fastapi>=0.115,<1
+uvicorn[standard]>=0.32,<1
+pydantic>=2.9,<3
+pydantic-settings>=2.6,<3
+python-multipart>=0.0.17,<1
+httpx>=0.28,<1
+supabase>=2.9,<3
+python-jose[cryptography]>=3.3,<4
+websockets>=13.1,<14
+sse-starlette>=2.1,<3

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI route modules."""
+
+from . import generate, health, models
+
+__all__ = ["generate", "health", "models"]

--- a/api/routes/deps.py
+++ b/api/routes/deps.py
@@ -1,0 +1,12 @@
+"""FastAPI dependency helpers."""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from ..core import AgentBridge
+
+
+def get_bridge(request: Request) -> AgentBridge:
+    """Return the singleton bridge attached to app state at startup."""
+    return request.app.state.bridge

--- a/api/routes/deps.py
+++ b/api/routes/deps.py
@@ -1,12 +1,102 @@
-"""FastAPI dependency helpers."""
+"""FastAPI dependency helpers.
+
+Contains:
+- `get_bridge`: returns the singleton AgentBridge attached to app.state.
+- `require_auth`: HTTP dependency that verifies a Supabase-issued JWT in the
+  `Authorization: Bearer ...` header.
+- `require_auth_ws`: WebSocket variant that reads `?token=...` from the query
+  string because browsers can't set headers on native WebSockets.
+
+If `settings.auth_enabled` is false the auth dependencies fall through, which
+is useful for local development and the demo deployment. Production should
+always set AUTH_ENABLED=true.
+"""
 
 from __future__ import annotations
 
-from fastapi import Request
+import base64
+import json
+import logging
+from typing import Any
+
+from fastapi import Header, HTTPException, Request, WebSocket, status
 
 from ..core import AgentBridge
+from ..settings import get_settings
+
+logger = logging.getLogger("api.auth")
 
 
 def get_bridge(request: Request) -> AgentBridge:
-    """Return the singleton bridge attached to app state at startup."""
     return request.app.state.bridge
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any]:
+    """Decode a JWT's payload WITHOUT verifying the signature.
+
+    Signature verification is delegated to Supabase's GoTrue server when we
+    want strict checks (out of scope here because we'd need the JWKS). For
+    now we treat the token as opaque proof-of-login and just make sure it
+    parses and isn't expired. This prevents casual anonymous abuse while
+    staying easy to operate without a public key endpoint.
+    """
+    try:
+        _, payload_b64, _ = token.split(".")
+        # base64url decode with missing padding forgiving
+        padding = "=" * (-len(payload_b64) % 4)
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
+        return json.loads(payload_bytes)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="malformed JWT",
+        ) from exc
+
+
+async def require_auth(
+    authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+    settings = get_settings()
+    if not settings.auth_enabled:
+        return {"sub": "anonymous", "mode": "disabled"}
+
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing bearer token",
+        )
+    token = authorization.split(None, 1)[1]
+    payload = _decode_jwt_payload(token)
+
+    # Exp check
+    import time as _t
+    exp = payload.get("exp")
+    if isinstance(exp, (int, float)) and exp < _t.time():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="token expired",
+        )
+
+    # Issuer sanity check - we only trust tokens minted by our own project.
+    iss = payload.get("iss") or ""
+    if settings.supabase_url and settings.supabase_url not in iss:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="token issuer mismatch",
+        )
+    return payload
+
+
+async def require_auth_ws(websocket: WebSocket) -> bool:
+    """Return True if the WebSocket caller is authenticated."""
+    settings = get_settings()
+    if not settings.auth_enabled:
+        return True
+    token = websocket.query_params.get("token")
+    if not token:
+        return False
+    try:
+        _decode_jwt_payload(token)
+        return True
+    except HTTPException:
+        return False

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -1,0 +1,99 @@
+"""/generate (SSE) and /generate/ws (WebSocket) endpoints.
+
+The frontend may use either transport. SSE is simpler and plays nicely with
+plain `fetch` streaming; WebSocket is used when we need bidirectional
+messages (cancel, resume, attachment chunking) later.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from sse_starlette.sse import EventSourceResponse
+
+from ..core import AgentBridge
+from ..schemas import GenerateEvent, GenerateJob, GenerateRequest
+from ..settings import Settings, get_settings
+from .deps import get_bridge
+
+router = APIRouter(prefix="/generate", tags=["generate"])
+
+
+@router.post("", response_model=GenerateJob)
+async def create_job(
+    request: GenerateRequest,
+    bridge: AgentBridge = Depends(get_bridge),
+) -> GenerateJob:
+    job = bridge.start(request)
+    return GenerateJob(
+        job_id=job.job_id,
+        status=job.status,  # type: ignore[arg-type]
+        workspace=str(job.workspace),
+        created_at=job.created_at,
+    )
+
+
+@router.get("/{job_id}/events")
+async def stream_events(
+    job_id: str,
+    bridge: AgentBridge = Depends(get_bridge),
+) -> EventSourceResponse:
+    job = bridge.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job not found")
+
+    async def event_gen() -> AsyncIterator[dict[str, str]]:
+        async for ev in bridge.events(job_id):
+            yield {
+                "event": ev.stage,
+                "data": ev.model_dump_json(exclude_none=True),
+            }
+
+    return EventSourceResponse(event_gen())
+
+
+@router.websocket("/ws/{job_id}")
+async def websocket_events(
+    websocket: WebSocket,
+    job_id: str,
+) -> None:
+    bridge: AgentBridge = websocket.app.state.bridge
+    await websocket.accept()
+    job = bridge.get(job_id)
+    if not job:
+        await websocket.send_text(json.dumps({"stage": "error", "message": "job not found"}))
+        await websocket.close()
+        return
+    try:
+        async for ev in bridge.events(job_id):
+            await websocket.send_text(ev.model_dump_json(exclude_none=True))
+            if ev.stage in ("done", "error"):
+                break
+    except WebSocketDisconnect:
+        return
+    finally:
+        with asyncio.suppress(Exception):  # type: ignore[attr-defined]
+            await websocket.close()
+
+
+@router.post("/attachment", tags=["generate"])
+async def upload_attachment(
+    file: UploadFile,
+    settings: Settings = Depends(get_settings),
+) -> dict[str, str]:
+    """Tiny helper so the frontend can POST files to Supabase Storage via the
+    server (keeps the service-role key off the browser)."""
+
+    from ..core.supabase import StorageClient
+
+    if file.size and file.size > settings.max_upload_mb * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="attachment too large")
+    data = await file.read()
+    object_path = f"uploads/{file.filename}"
+    client = StorageClient(settings)
+    await client.upload(object_path, data, file.content_type or "application/octet-stream")
+    signed = await client.signed_url(object_path, expires_in=3600)
+    return {"object_path": object_path, "signed_url": signed}

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -38,9 +38,10 @@ def _safe_filename(name: str | None) -> str:
 async def create_job(
     request: GenerateRequest,
     bridge: AgentBridge = Depends(get_bridge),
-    _auth: dict = Depends(require_auth),
+    auth: dict = Depends(require_auth),
 ) -> GenerateJob:
-    job = bridge.start(request)
+    owner_sub = auth.get("sub") if isinstance(auth, dict) else None
+    job = bridge.start(request, owner_sub=owner_sub)
     return GenerateJob(
         job_id=job.job_id,
         status=job.status,  # type: ignore[arg-type]
@@ -55,7 +56,8 @@ async def stream_events(
     bridge: AgentBridge = Depends(get_bridge),
     _auth: dict = Depends(require_auth),
 ) -> EventSourceResponse:
-    job = bridge.get(job_id)
+    # Fall back to Postgres restore so reconnects after a cold-stop still work.
+    job = bridge.get(job_id) or await bridge.restore(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="job not found")
 

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, WebSocket, We
 from sse_starlette.sse import EventSourceResponse
 
 from ..core import AgentBridge
-from ..schemas import GenerateEvent, GenerateJob, GenerateRequest
+from ..schemas import GenerateJob, GenerateRequest
 from ..settings import Settings, get_settings
 from .deps import get_bridge
 

--- a/api/routes/generate.py
+++ b/api/routes/generate.py
@@ -7,8 +7,10 @@ messages (cancel, resume, attachment chunking) later.
 
 from __future__ import annotations
 
-import asyncio
+import contextlib
 import json
+import re
+import uuid
 from typing import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
@@ -17,15 +19,26 @@ from sse_starlette.sse import EventSourceResponse
 from ..core import AgentBridge
 from ..schemas import GenerateJob, GenerateRequest
 from ..settings import Settings, get_settings
-from .deps import get_bridge
+from .deps import get_bridge, require_auth, require_auth_ws
 
 router = APIRouter(prefix="/generate", tags=["generate"])
+
+
+_FILENAME_SAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_filename(name: str | None) -> str:
+    """Strip directory separators and restrict to a conservative charset."""
+    base = (name or "").rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    clean = _FILENAME_SAFE.sub("_", base)[:120]
+    return clean or "upload"
 
 
 @router.post("", response_model=GenerateJob)
 async def create_job(
     request: GenerateRequest,
     bridge: AgentBridge = Depends(get_bridge),
+    _auth: dict = Depends(require_auth),
 ) -> GenerateJob:
     job = bridge.start(request)
     return GenerateJob(
@@ -40,6 +53,7 @@ async def create_job(
 async def stream_events(
     job_id: str,
     bridge: AgentBridge = Depends(get_bridge),
+    _auth: dict = Depends(require_auth),
 ) -> EventSourceResponse:
     job = bridge.get(job_id)
     if not job:
@@ -59,8 +73,14 @@ async def stream_events(
 async def websocket_events(
     websocket: WebSocket,
     job_id: str,
+    bridge: AgentBridge = Depends(get_bridge),
 ) -> None:
-    bridge: AgentBridge = websocket.app.state.bridge
+    # WebSocket auth piggybacks on the query string (`?token=...`) because
+    # browsers can't attach an Authorization header to native WebSockets.
+    ok = await require_auth_ws(websocket)
+    if not ok:
+        await websocket.close(code=4401)
+        return
     await websocket.accept()
     job = bridge.get(job_id)
     if not job:
@@ -75,7 +95,7 @@ async def websocket_events(
     except WebSocketDisconnect:
         return
     finally:
-        with asyncio.suppress(Exception):  # type: ignore[attr-defined]
+        with contextlib.suppress(Exception):
             await websocket.close()
 
 
@@ -83,16 +103,24 @@ async def websocket_events(
 async def upload_attachment(
     file: UploadFile,
     settings: Settings = Depends(get_settings),
+    _auth: dict = Depends(require_auth),
 ) -> dict[str, str]:
-    """Tiny helper so the frontend can POST files to Supabase Storage via the
-    server (keeps the service-role key off the browser)."""
+    """Accept a user attachment and forward it to Supabase Storage.
 
+    The client-supplied filename is sanitized and prefixed with a server-
+    generated UUID, so a malicious actor can't overwrite other objects or
+    escape the `uploads/` namespace.
+    """
     from ..core.supabase import StorageClient
 
-    if file.size and file.size > settings.max_upload_mb * 1024 * 1024:
+    limit = settings.max_upload_mb * 1024 * 1024
+    # Stream-read with a hard cap - don't rely on declared Content-Length.
+    data = await file.read(limit + 1)
+    if len(data) > limit:
         raise HTTPException(status_code=413, detail="attachment too large")
-    data = await file.read()
-    object_path = f"uploads/{file.filename}"
+
+    name = _safe_filename(file.filename)
+    object_path = f"uploads/{uuid.uuid4().hex[:12]}/{name}"
     client = StorageClient(settings)
     await client.upload(object_path, data, file.content_type or "application/octet-stream")
     signed = await client.signed_url(object_path, expires_in=3600)

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,0 +1,37 @@
+"""/health and /readiness endpoints.
+
+Separate from /readiness because Railway/Fly use different semantics - a
+passing /health means the process is up, /readiness additionally verifies
+Supabase credentials and deeppresenter importability.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+
+from fastapi import APIRouter
+
+from ..settings import get_settings
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/readiness")
+async def readiness() -> dict[str, object]:
+    settings = get_settings()
+    deeppresenter_ok = importlib.util.find_spec("deeppresenter") is not None
+    docker_cli = shutil.which("docker") is not None
+    return {
+        "status": "ok" if deeppresenter_ok else "degraded",
+        "deeppresenter_importable": deeppresenter_ok,
+        "docker_cli_available": docker_cli,
+        "supabase_configured": bool(settings.supabase_url and settings.supabase_service_role_key),
+        "edge_function_configured": bool(settings.supabase_edge_function_url),
+        "workspace_base": str(settings.workspace_base),
+    }

--- a/api/routes/models.py
+++ b/api/routes/models.py
@@ -1,0 +1,75 @@
+"""/models endpoint - static catalog of Google models for the dropdown.
+
+The frontend calls this once on load to hydrate the model selector. Defaults
+map onto deeppresenter's config sections so the user understands which slot
+each model fills.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from ..schemas import ModelCatalog, ModelKind, ModelOption
+from ..settings import get_settings
+
+router = APIRouter(tags=["models"])
+
+
+GOOGLE_MODELS: list[ModelOption] = [
+    ModelOption(
+        id="google/imagen-3.0-generate-002",
+        label="Imagen 3.0 (Standard)",
+        kind=ModelKind.image,
+        default_for=["t2i_model"],
+        notes="기본 이미지 생성 모델. 고품질 16:9 커버/일러스트.",
+    ),
+    ModelOption(
+        id="google/imagen-3.0-fast-generate-001",
+        label="Imagen 3.0 Fast",
+        kind=ModelKind.image,
+        notes="빠른 프리뷰용.",
+    ),
+    ModelOption(
+        id="google/gemini-2.0-flash",
+        label="Gemini 2.0 Flash",
+        kind=ModelKind.chat,
+        default_for=["research_agent"],
+        notes="리서치 단계 기본 텍스트 모델. 빠르고 저렴.",
+    ),
+    ModelOption(
+        id="google/gemini-2.5-flash",
+        label="Gemini 2.5 Flash",
+        kind=ModelKind.chat,
+        default_for=["long_context_model"],
+        notes="긴 문맥 처리용.",
+    ),
+    ModelOption(
+        id="google/gemini-2.5-pro",
+        label="Gemini 2.5 Pro",
+        kind=ModelKind.chat,
+        default_for=["design_agent"],
+        notes="디자인 에이전트 고품질 모드.",
+    ),
+    ModelOption(
+        id="google/gemini-2.0-flash-vision",
+        label="Gemini 2.0 Flash Vision",
+        kind=ModelKind.vision,
+        default_for=["vision_model"],
+        notes="비전 모델 - 참조 슬라이드 이미지 분석.",
+    ),
+]
+
+
+@router.get("/models", response_model=ModelCatalog)
+async def list_models() -> ModelCatalog:
+    s = get_settings()
+    return ModelCatalog(
+        models=GOOGLE_MODELS,
+        defaults={
+            "t2i_model": s.default_t2i_model,
+            "research_agent": s.default_chat_model,
+            "long_context_model": s.default_long_context_model,
+            "vision_model": s.default_vision_model,
+            "design_agent": s.default_design_model,
+        },
+    )

--- a/api/ruff.toml
+++ b/api/ruff.toml
@@ -1,0 +1,15 @@
+# Lint config scoped to the FastAPI wrapper only. The upstream deeppresenter/
+# and pptagent/ packages are still governed by their own .pre-commit-config.yaml
+# and are intentionally not covered by this file.
+line-length = 100
+target-version = "py312"
+
+[lint]
+select = ["E", "F", "W", "I"]
+# E501 is re-enabled via line-length above.
+# UP042 (StrEnum) is skipped because mypy-friendly `(str, Enum)` pattern is
+# more portable for libraries that still type-check against Python 3.10.
+ignore = ["E501"]
+
+[lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,88 @@
+"""Pydantic schemas shared by routes and bridge."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ModelKind(str, Enum):
+    chat = "chat"
+    vision = "vision"
+    image = "image"
+
+
+class ModelOption(BaseModel):
+    """A single selectable model entry for the frontend dropdown."""
+
+    id: str
+    label: str
+    kind: ModelKind
+    family: Literal["google"] = "google"
+    default_for: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class ModelCatalog(BaseModel):
+    models: list[ModelOption]
+    defaults: dict[str, str]
+
+
+class ModelOverrides(BaseModel):
+    """Optional per-request model overrides.
+
+    If a field is None, the FastAPI default from `Settings` is used. These
+    names map 1:1 onto the sections of `deeppresenter/config.yaml`.
+    """
+
+    research_agent: str | None = None
+    design_agent: str | None = None
+    long_context_model: str | None = None
+    vision_model: str | None = None
+    t2i_model: str | None = None
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(..., min_length=2, max_length=8000)
+    attachments: list[str] = Field(
+        default_factory=list,
+        description="Supabase Storage object paths already uploaded by the client",
+    )
+    pages: str | None = Field(
+        default=None,
+        description='Page range for PDF attachments, e.g. "10-12"',
+    )
+    models: ModelOverrides = Field(default_factory=ModelOverrides)
+    output_name: str = Field(default="presentation.pptx")
+
+
+class GenerateJob(BaseModel):
+    job_id: str
+    status: Literal["queued", "running", "succeeded", "failed"]
+    workspace: str
+    created_at: float
+
+
+class GenerateEvent(BaseModel):
+    """One streamed progress event."""
+
+    job_id: str
+    stage: Literal[
+        "research",
+        "outline",
+        "design",
+        "render",
+        "export",
+        "upload",
+        "done",
+        "error",
+        "log",
+    ]
+    message: str
+    percent: float | None = None
+    slide_index: int | None = None
+    slide_preview_url: str | None = None
+    pptx_url: str | None = None
+    error: str | None = None

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,0 +1,61 @@
+"""Environment-backed settings for the FastAPI wrapper.
+
+Everything that the web layer needs to know about Supabase and the sandbox
+workspace lives here. The Google API key is *never* loaded on this side - it
+stays in the Supabase Edge Function's secret store.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime settings for the API server."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    # --- Supabase ------------------------------------------------------------
+    supabase_url: str = Field(default="", description="Supabase project URL")
+    supabase_service_role_key: str = Field(
+        default="", description="Service role key - server-side only"
+    )
+    supabase_edge_function_url: str = Field(
+        default="",
+        description="Fully-qualified URL of the deployed llm-proxy Edge Function",
+    )
+    supabase_storage_bucket: str = Field(default="presentations")
+
+    # --- PPTAgent runtime ----------------------------------------------------
+    workspace_base: Path = Field(
+        default=Path.home() / ".cache" / "deeppresenter",
+        description="Root folder where AgentLoop writes per-run artifacts",
+    )
+    offline_mode: bool = Field(default=False)
+
+    # --- Model defaults (overridable per request) ----------------------------
+    default_t2i_model: str = Field(default="google/imagen-3.0-generate-002")
+    default_chat_model: str = Field(default="google/gemini-2.0-flash")
+    default_long_context_model: str = Field(default="google/gemini-2.5-flash")
+    default_vision_model: str = Field(default="google/gemini-2.0-flash-vision")
+    default_design_model: str = Field(default="google/gemini-2.5-pro")
+
+    # --- Server --------------------------------------------------------------
+    cors_origins: list[str] = Field(
+        default_factory=lambda: ["http://localhost:3000"]
+    )
+    max_upload_mb: int = Field(default=50)
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()

--- a/api/settings.py
+++ b/api/settings.py
@@ -49,9 +49,25 @@ class Settings(BaseSettings):
     default_vision_model: str = Field(default="google/gemini-2.0-flash-vision")
     default_design_model: str = Field(default="google/gemini-2.5-pro")
 
+    # --- Auth ---------------------------------------------------------------
+    auth_enabled: bool = Field(
+        default=True,
+        description="When false, JWT verification is skipped - dev only.",
+    )
+
     # --- Server --------------------------------------------------------------
     cors_origins: list[str] = Field(
-        default_factory=lambda: ["http://localhost:3000"]
+        default_factory=lambda: [
+            "http://localhost:3000",
+            "https://rkdghkclgns-design.github.io",
+        ],
+        description="Browsers allowed to call the API. Production MUST include the deployed frontend origin.",
+    )
+    cors_allow_methods: list[str] = Field(
+        default_factory=lambda: ["GET", "POST", "OPTIONS"]
+    )
+    cors_allow_headers: list[str] = Field(
+        default_factory=lambda: ["authorization", "content-type", "x-requested-with"]
     )
     max_upload_mb: int = Field(default=50)
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,75 @@
+# Deployment
+
+## 로컬 풀스택 (Docker Compose)
+
+```bash
+# 1. Supabase 엣지 펑션 먼저 배포
+cd supabase
+supabase link --project-ref <ref>
+supabase functions deploy llm-proxy
+supabase secrets set GOOGLE_API_KEY=<key>
+
+# 2. 환경파일 준비
+cp ../api/.env.example ../api/.env      # 값 채우기
+cp ../web/.env.local.example ../web/.env.local
+
+# 3. 풀스택 기동 (WSL2 또는 Docker Desktop 켜진 Windows)
+cd ..
+docker compose -f deploy/docker-compose.prod.yml up -d --build
+# 프론트 → http://localhost:3000
+# API   → http://localhost:7870/readiness
+```
+
+## Railway (API 전용)
+
+프론트는 Vercel 로, API 는 Railway 로 분리하는 구성이 권장됩니다.
+
+```bash
+railway init
+railway link <project>
+railway up --detach
+# Dashboard → Variables 에 api/.env.example 값 주입
+```
+
+`deploy/railway.json` 은 Railway 가 자동 인식합니다. `DOCKER_HOST` 를
+별도 제공해 샌드박스 컨테이너 실행을 위임하세요.
+
+## Fly.io (API 전용)
+
+```bash
+fly launch --copy-config --config deploy/fly.toml --now
+fly secrets set $(cat api/.env | xargs)
+```
+
+> 샌드박스가 필요한 경로(이미지 생성, 브라우저 렌더)는 fly 머신 CPU/메모리를
+> 넉넉히 줍니다. 권장: `shared-cpu-2x / 2GB` 이상.
+
+## Vercel (프론트)
+
+```bash
+cd web
+vercel link
+vercel env add NEXT_PUBLIC_API_ORIGIN          # Railway/Fly 의 API URL
+vercel env add NEXT_PUBLIC_SUPABASE_URL
+vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY
+vercel --prod
+```
+
+## 환경변수 요약
+
+| 변수 | 배치 | 설명 |
+|------|------|------|
+| `GOOGLE_API_KEY` | **Supabase Secret** | Google Imagen/Gemini 호출 유일 키 |
+| `SUPABASE_URL` | api + web | 프로젝트 URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | api (서버) | Edge Function 호출 및 Storage 업로드 |
+| `SUPABASE_ANON_KEY` | web | 브라우저 클라이언트 |
+| `SUPABASE_EDGE_FUNCTION_URL` | api | `https://<ref>.supabase.co/functions/v1/llm-proxy` |
+| `NEXT_PUBLIC_API_ORIGIN` | web | FastAPI 공개 URL |
+
+## 헬스체크
+
+| 엔드포인트 | 기대값 |
+|-----------|-------|
+| `GET /health` | `{ "status": "ok" }` |
+| `GET /readiness` | 모든 bool 필드가 `true` |
+| `GET /models` | Google 모델 배열 + `defaults.t2i_model = "google/imagen-3.0-generate-002"` |

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,41 @@
+# Full-stack production compose.
+#
+#   docker compose -f deploy/docker-compose.prod.yml up -d
+#
+# Assumes: (a) deeppresenter-sandbox image is already present on the host,
+# (b) the .env file at repo root contains both api/ and web/ secrets.
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: api/Dockerfile
+    image: pptagent-api:latest
+    env_file: ../api/.env
+    environment:
+      CORS_ORIGINS: '["http://localhost:3000","https://pptagent.example.com"]'
+      WORKSPACE_BASE: /workspace
+    volumes:
+      - workspace:/workspace
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - "7870:7870"
+    restart: unless-stopped
+
+  web:
+    build:
+      context: ../web
+      dockerfile: Dockerfile
+    image: pptagent-web:latest
+    env_file: ../web/.env.local
+    environment:
+      NEXT_PUBLIC_API_ORIGIN: http://api:7870
+    depends_on:
+      - api
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+
+volumes:
+  workspace: {}

--- a/deploy/fly.toml
+++ b/deploy/fly.toml
@@ -1,0 +1,42 @@
+app = "pptagent-api"
+primary_region = "nrt"
+
+[build]
+  dockerfile = "api/Dockerfile"
+
+[env]
+  HOST = "0.0.0.0"
+  PORT = "7870"
+  WORKSPACE_BASE = "/data/workspace"
+
+[[mounts]]
+  source = "pptagent_data"
+  destination = "/data"
+
+[[services]]
+  internal_port = 7870
+  protocol = "tcp"
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+    force_https = true
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.http_checks]]
+    grace_period = "15s"
+    interval = "30s"
+    method = "get"
+    path = "/health"
+    protocol = "http"
+    timeout = "5s"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 2
+  memory_mb = 2048

--- a/deploy/railway.json
+++ b/deploy/railway.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "api/Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "uvicorn api.main:app --host 0.0.0.0 --port $PORT",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3,
+    "numReplicas": 1
+  }
+}

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,4 @@
+.branches
+.temp
+.env
+supabase/.temp

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,71 @@
+# Supabase Layer
+
+This folder holds everything that lives on Supabase: the `llm-proxy` Edge Function and the Storage buckets the FastAPI backend writes PPTX files into.
+
+## 기존 Supabase 프로젝트 이용
+
+이 레포는 **기존 Supabase 프로젝트에 붙는 형태**로 설계돼 있습니다. 새 프로젝트를 만들 필요는 없고, 다음 두 가지만 확인하세요.
+
+1. Edge Functions 가 enabled 되어 있는지 (기본 활성).
+2. Storage 에 `presentations` 버킷이 있는지. 없으면 콘솔에서 프라이빗 버킷으로 1개만 생성.
+
+## 설치
+
+```bash
+# Supabase CLI (scoop 또는 npm global)
+scoop install supabase
+# 또는
+npm install -g supabase
+
+# 프로젝트 연결 (project-ref 는 Supabase 대시보드의 Settings → General 에서 확인)
+cd supabase
+supabase link --project-ref <YOUR_PROJECT_REF>
+
+# Edge Function 배포
+supabase functions deploy llm-proxy --no-verify-jwt
+# (인증이 필요한 경우 --no-verify-jwt 옵션 제거)
+
+# 시크릿 등록 (Google API 키는 여기에만 둠)
+supabase secrets set GOOGLE_API_KEY="AIza..." --project-ref <YOUR_PROJECT_REF>
+```
+
+## 호출 예시
+
+```bash
+curl -X POST https://<ref>.supabase.co/functions/v1/llm-proxy \
+  -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "google/gemini-2.0-flash",
+    "messages": [{"role":"user","content":"Hello"}]
+  }'
+```
+
+Imagen (기본 T2I 모델):
+
+```bash
+curl -X POST https://<ref>.supabase.co/functions/v1/llm-proxy \
+  -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "google/imagen-3.0-generate-002",
+    "prompt": "a minimal cover illustration for a quarterly report",
+    "aspect_ratio": "16:9"
+  }'
+```
+
+응답은 OpenAI 호환 형태이므로 `deeppresenter` 의 `apis.py` 가 그대로 소비합니다.
+
+## 지원 모델 목록 (기본값은 Imagen)
+
+| id | 종류 | 용도 |
+|----|-----|-----|
+| `google/imagen-3.0-generate-002` | image | **기본 t2i_model** |
+| `google/imagen-3.0-fast-generate-001` | image | 빠른 초안 |
+| `google/gemini-2.0-flash` | chat | research_agent 기본 |
+| `google/gemini-2.0-flash-exp` | chat | 실험 |
+| `google/gemini-2.5-pro` | chat | design_agent 고품질 |
+| `google/gemini-2.5-flash` | chat | 긴 문맥 |
+| `google/gemini-2.0-flash-vision` | vision | vision_model |
+
+프론트엔드의 모델 선택 드롭다운은 [web/lib/models.ts](../web/lib/models.ts) 에서 관리합니다.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,30 @@
+# Supabase project config template.
+# Copy to supabase/.supabase/config.toml or link via `supabase link --project-ref <ref>`.
+project_id = "REPLACE_WITH_YOUR_PROJECT_REF"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "storage"]
+
+[storage]
+enabled = true
+file_size_limit = "200MiB"
+
+[storage.buckets.presentations]
+public = false
+file_size_limit = "200MiB"
+allowed_mime_types = [
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/pdf",
+  "image/png",
+  "image/jpeg"
+]
+
+[edge_runtime]
+enabled = true
+policy = "oneshot"
+inspector_port = 8083
+
+[functions.llm-proxy]
+verify_jwt = true

--- a/supabase/functions/llm-proxy/deno.json
+++ b/supabase/functions/llm-proxy/deno.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
+  },
+  "fmt": {
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "semiColons": true,
+    "singleQuote": false
+  }
+}

--- a/supabase/functions/llm-proxy/deno.json
+++ b/supabase/functions/llm-proxy/deno.json
@@ -10,7 +10,7 @@
   },
   "fmt": {
     "indentWidth": 2,
-    "lineWidth": 100,
+    "lineWidth": 140,
     "semiColons": true,
     "singleQuote": false
   }

--- a/supabase/functions/llm-proxy/index.ts
+++ b/supabase/functions/llm-proxy/index.ts
@@ -33,8 +33,7 @@ const GENAI_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 const CORS_HEADERS: HeadersInit = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 

--- a/supabase/functions/llm-proxy/index.ts
+++ b/supabase/functions/llm-proxy/index.ts
@@ -27,25 +27,47 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 const GOOGLE_API_KEY = Deno.env.get("GOOGLE_API_KEY") ?? "";
 const GENAI_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
+// Fail loudly on cold start so misconfiguration shows up in the deploy log.
+if (!GOOGLE_API_KEY) {
+  console.error("llm-proxy: GOOGLE_API_KEY is not set - requests will 500");
+}
+
 // ----------------------------------------------------------------------------
 // CORS / auth helpers
 // ----------------------------------------------------------------------------
 
-const CORS_HEADERS: HeadersInit = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+// Allow-list of browser origins. The FastAPI server (server-to-server) does
+// not trigger CORS, so keep this list tight.
+const ALLOWED_ORIGINS = new Set(
+  (Deno.env.get("ALLOWED_ORIGINS") ?? "https://rkdghkclgns-design.github.io,http://localhost:3000")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
 
-function json(body: unknown, init: ResponseInit = {}): Response {
+function corsHeaders(origin: string | null): HeadersInit {
+  const allow = origin && ALLOWED_ORIGINS.has(origin) ? origin : "null";
+  return {
+    "Access-Control-Allow-Origin": allow,
+    "Vary": "Origin",
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Max-Age": "3600",
+  };
+}
+
+function json(body: unknown, origin: string | null, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
     ...init,
-    headers: { ...CORS_HEADERS, "content-type": "application/json", ...(init.headers ?? {}) },
+    headers: { ...corsHeaders(origin), "content-type": "application/json", ...(init.headers ?? {}) },
   });
 }
 
-function bad(status: number, message: string, details?: unknown): Response {
-  return json({ error: { message, status, details } }, { status });
+function bad(origin: string | null, status: number, message: string, details?: unknown): Response {
+  // Upstream error bodies can leak infrastructure metadata; keep the reply
+  // generic for untrusted callers and log the raw body for the operator.
+  if (details) console.warn("llm-proxy error detail", { status, message, details });
+  return json({ error: { message, status } }, origin, { status });
 }
 
 // ----------------------------------------------------------------------------
@@ -56,6 +78,11 @@ type ChatMessage = {
   role: "system" | "user" | "assistant";
   content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
 };
+
+// Hosts whose images we trust to hand to Gemini as a fileUri. Anything outside
+// this allowlist is dropped to stop callers from using this function as an
+// SSRF proxy into internal networks.
+const TRUSTED_IMAGE_HOSTS = /^(?:[a-z0-9-]+\.)*(?:supabase\.co|supabase\.in|githubusercontent\.com|unsplash\.com|googleusercontent\.com)$/i;
 
 function toGeminiParts(content: ChatMessage["content"]): any[] {
   if (typeof content === "string") return [{ text: content }];
@@ -70,7 +97,16 @@ function toGeminiParts(content: ChatMessage["content"]): any[] {
         const mimeType = meta.split(";")[0] || "image/png";
         parts.push({ inlineData: { mimeType, data } });
       } else {
-        parts.push({ fileData: { mimeType: "image/*", fileUri: url } });
+        try {
+          const parsed = new URL(url);
+          if (parsed.protocol !== "https:" || !TRUSTED_IMAGE_HOSTS.test(parsed.hostname)) {
+            console.warn("llm-proxy: dropped untrusted image_url", parsed.hostname);
+            continue;
+          }
+          parts.push({ fileData: { mimeType: "image/*", fileUri: url } });
+        } catch {
+          // malformed URL - skip
+        }
       }
     }
   }
@@ -82,7 +118,8 @@ function messagesToGemini(messages: ChatMessage[]): { systemInstruction?: any; c
   let systemInstruction: any | undefined;
   for (const m of messages) {
     if (m.role === "system") {
-      systemInstruction = { role: "user", parts: toGeminiParts(m.content) };
+      // Gemini's systemInstruction field doesn't take a `role` key - just parts.
+      systemInstruction = { parts: toGeminiParts(m.content) };
       continue;
     }
     contents.push({
@@ -123,7 +160,13 @@ function geminiToOpenAI(model: string, resp: any): any {
 // Endpoint handlers
 // ----------------------------------------------------------------------------
 
-async function handleChat(model: string, body: any): Promise<Response> {
+const googleAuthHeaders = (): HeadersInit => ({
+  "content-type": "application/json",
+  // Use a header instead of ?key=... to keep the API key out of URL-based logs.
+  "x-goog-api-key": GOOGLE_API_KEY,
+});
+
+async function handleChat(origin: string | null, model: string, body: any): Promise<Response> {
   const googleModel = model.replace(/^google\//, "");
   const { systemInstruction, contents } = messagesToGemini(body.messages ?? []);
   const payload: any = {
@@ -136,22 +179,22 @@ async function handleChat(model: string, body: any): Promise<Response> {
   };
   if (systemInstruction) payload.systemInstruction = systemInstruction;
 
-  const url = `${GENAI_BASE}/models/${encodeURIComponent(googleModel)}:generateContent?key=${GOOGLE_API_KEY}`;
+  const url = `${GENAI_BASE}/models/${encodeURIComponent(googleModel)}:generateContent`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: googleAuthHeaders(),
     body: JSON.stringify(payload),
   });
-  if (!res.ok) return bad(res.status, "gemini upstream error", await res.text());
+  if (!res.ok) return bad(origin, res.status, "gemini upstream error", await res.text());
   const data = await res.json();
-  return json(geminiToOpenAI(model, data));
+  return json(geminiToOpenAI(model, data), origin);
 }
 
-async function handleImage(model: string, body: any): Promise<Response> {
+async function handleImage(origin: string | null, model: string, body: any): Promise<Response> {
   const googleModel = model.replace(/^google\//, "");
   const prompt = body.prompt ??
     (Array.isArray(body.messages) ? body.messages.at(-1)?.content : "") ?? "";
-  if (!prompt) return bad(400, "prompt is required for image models");
+  if (!prompt) return bad(origin, 400, "prompt is required for image models");
 
   const payload = {
     instances: [{ prompt }],
@@ -162,13 +205,13 @@ async function handleImage(model: string, body: any): Promise<Response> {
       personGeneration: "allow_adult",
     },
   };
-  const url = `${GENAI_BASE}/models/${encodeURIComponent(googleModel)}:predict?key=${GOOGLE_API_KEY}`;
+  const url = `${GENAI_BASE}/models/${encodeURIComponent(googleModel)}:predict`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: googleAuthHeaders(),
     body: JSON.stringify(payload),
   });
-  if (!res.ok) return bad(res.status, "imagen upstream error", await res.text());
+  if (!res.ok) return bad(origin, res.status, "imagen upstream error", await res.text());
   const data = await res.json();
   const predictions = data?.predictions ?? [];
   return json({
@@ -178,7 +221,7 @@ async function handleImage(model: string, body: any): Promise<Response> {
       b64_json: p?.bytesBase64Encoded ?? null,
       revised_prompt: p?.prompt ?? prompt,
     })),
-  });
+  }, origin);
 }
 
 // ----------------------------------------------------------------------------
@@ -194,23 +237,26 @@ function routeModel(model: string): "chat" | "image" | null {
 }
 
 serve(async (req) => {
-  if (req.method === "OPTIONS") return new Response(null, { headers: CORS_HEADERS });
-  if (req.method !== "POST") return bad(405, "method not allowed");
-  if (!GOOGLE_API_KEY) return bad(500, "GOOGLE_API_KEY secret is not configured");
+  const origin = req.headers.get("origin");
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders(origin) });
+  if (req.method !== "POST") return bad(origin, 405, "method not allowed");
+  if (!GOOGLE_API_KEY) return bad(origin, 500, "GOOGLE_API_KEY secret is not configured");
 
   let body: any;
   try {
     body = await req.json();
   } catch {
-    return bad(400, "invalid JSON body");
+    return bad(origin, 400, "invalid JSON body");
   }
   const model = String(body.model ?? "");
   const kind = routeModel(model);
-  if (!kind) return bad(400, `unsupported model "${model}"`);
+  if (!kind) return bad(origin, 400, `unsupported model "${model}"`);
 
   try {
-    return kind === "image" ? await handleImage(model, body) : await handleChat(model, body);
+    return kind === "image"
+      ? await handleImage(origin, model, body)
+      : await handleChat(origin, model, body);
   } catch (err) {
-    return bad(500, "proxy exception", String(err));
+    return bad(origin, 500, "proxy exception", String(err));
   }
 });

--- a/supabase/functions/llm-proxy/index.ts
+++ b/supabase/functions/llm-proxy/index.ts
@@ -1,0 +1,217 @@
+// Supabase Edge Function: llm-proxy
+//
+// Centralised proxy for all Google API calls. The API key never leaves this
+// function - neither the browser nor the FastAPI server sees it. FastAPI
+// forwards OpenAI-compatible chat/image requests here, the function fans them
+// out to the correct Google endpoint (Gemini for chat/vision, Imagen for T2I),
+// and returns an OpenAI-shaped response so `deeppresenter` can consume it
+// without modification.
+//
+// Deployment:
+//   supabase functions deploy llm-proxy --project-ref <ref>
+//   supabase secrets set GOOGLE_API_KEY=<key> --project-ref <ref>
+//
+// Accepted request body (OpenAI-style):
+//   { model: string, messages?: ChatMessage[], prompt?: string,
+//     temperature?: number, max_tokens?: number, response_format?: any, n?: number }
+//
+// Routing rules (model id -> Google endpoint):
+//   google/imagen-*              -> Imagen T2I (default for t2i_model)
+//   google/gemini-*-vision       -> Gemini generateContent with inlineData parts
+//   google/gemini-*              -> Gemini generateContent (text)
+//   <any other>                  -> 400 (unsupported)
+
+// deno-lint-ignore-file no-explicit-any
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+
+const GOOGLE_API_KEY = Deno.env.get("GOOGLE_API_KEY") ?? "";
+const GENAI_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+// ----------------------------------------------------------------------------
+// CORS / auth helpers
+// ----------------------------------------------------------------------------
+
+const CORS_HEADERS: HeadersInit = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { ...CORS_HEADERS, "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+function bad(status: number, message: string, details?: unknown): Response {
+  return json({ error: { message, status, details } }, { status });
+}
+
+// ----------------------------------------------------------------------------
+// OpenAI <-> Google Gemini translation
+// ----------------------------------------------------------------------------
+
+type ChatMessage = {
+  role: "system" | "user" | "assistant";
+  content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+};
+
+function toGeminiParts(content: ChatMessage["content"]): any[] {
+  if (typeof content === "string") return [{ text: content }];
+  const parts: any[] = [];
+  for (const chunk of content) {
+    if (chunk.type === "text" && chunk.text) {
+      parts.push({ text: chunk.text });
+    } else if (chunk.type === "image_url" && chunk.image_url?.url) {
+      const url = chunk.image_url.url;
+      if (url.startsWith("data:")) {
+        const [meta, data] = url.slice(5).split(",", 2);
+        const mimeType = meta.split(";")[0] || "image/png";
+        parts.push({ inlineData: { mimeType, data } });
+      } else {
+        parts.push({ fileData: { mimeType: "image/*", fileUri: url } });
+      }
+    }
+  }
+  return parts;
+}
+
+function messagesToGemini(messages: ChatMessage[]): { systemInstruction?: any; contents: any[] } {
+  const contents: any[] = [];
+  let systemInstruction: any | undefined;
+  for (const m of messages) {
+    if (m.role === "system") {
+      systemInstruction = { role: "user", parts: toGeminiParts(m.content) };
+      continue;
+    }
+    contents.push({
+      role: m.role === "assistant" ? "model" : "user",
+      parts: toGeminiParts(m.content),
+    });
+  }
+  return { systemInstruction, contents };
+}
+
+function geminiToOpenAI(model: string, resp: any): any {
+  const candidate = resp?.candidates?.[0];
+  const text = candidate?.content?.parts
+    ?.map((p: any) => p.text ?? "")
+    .filter(Boolean)
+    .join("") ?? "";
+  return {
+    id: `chatcmpl-${crypto.randomUUID()}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: text },
+        finish_reason: candidate?.finishReason?.toLowerCase() ?? "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: resp?.usageMetadata?.promptTokenCount ?? 0,
+      completion_tokens: resp?.usageMetadata?.candidatesTokenCount ?? 0,
+      total_tokens: resp?.usageMetadata?.totalTokenCount ?? 0,
+    },
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Endpoint handlers
+// ----------------------------------------------------------------------------
+
+async function handleChat(model: string, body: any): Promise<Response> {
+  const googleModel = model.replace(/^google\//, "");
+  const { systemInstruction, contents } = messagesToGemini(body.messages ?? []);
+  const payload: any = {
+    contents,
+    generationConfig: {
+      temperature: body.temperature,
+      maxOutputTokens: body.max_tokens,
+      responseMimeType: body.response_format?.type === "json_object" ? "application/json" : undefined,
+    },
+  };
+  if (systemInstruction) payload.systemInstruction = systemInstruction;
+
+  const url = `${GENAI_BASE}/models/${encodeURIComponent(googleModel)}:generateContent?key=${GOOGLE_API_KEY}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) return bad(res.status, "gemini upstream error", await res.text());
+  const data = await res.json();
+  return json(geminiToOpenAI(model, data));
+}
+
+async function handleImage(model: string, body: any): Promise<Response> {
+  const googleModel = model.replace(/^google\//, "");
+  const prompt = body.prompt ??
+    (Array.isArray(body.messages) ? body.messages.at(-1)?.content : "") ?? "";
+  if (!prompt) return bad(400, "prompt is required for image models");
+
+  const payload = {
+    instances: [{ prompt }],
+    parameters: {
+      sampleCount: body.n ?? 1,
+      aspectRatio: body.aspect_ratio ?? "16:9",
+      safetyFilterLevel: "block_few",
+      personGeneration: "allow_adult",
+    },
+  };
+  const url = `${GENAI_BASE}/models/${encodeURIComponent(googleModel)}:predict?key=${GOOGLE_API_KEY}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) return bad(res.status, "imagen upstream error", await res.text());
+  const data = await res.json();
+  const predictions = data?.predictions ?? [];
+  return json({
+    created: Math.floor(Date.now() / 1000),
+    model,
+    data: predictions.map((p: any) => ({
+      b64_json: p?.bytesBase64Encoded ?? null,
+      revised_prompt: p?.prompt ?? prompt,
+    })),
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Router
+// ----------------------------------------------------------------------------
+
+function routeModel(model: string): "chat" | "image" | null {
+  if (!model) return null;
+  const m = model.toLowerCase();
+  if (m.startsWith("google/imagen") || m.includes("imagegeneration")) return "image";
+  if (m.startsWith("google/gemini")) return "chat";
+  return null;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: CORS_HEADERS });
+  if (req.method !== "POST") return bad(405, "method not allowed");
+  if (!GOOGLE_API_KEY) return bad(500, "GOOGLE_API_KEY secret is not configured");
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return bad(400, "invalid JSON body");
+  }
+  const model = String(body.model ?? "");
+  const kind = routeModel(model);
+  if (!kind) return bad(400, `unsupported model "${model}"`);
+
+  try {
+    return kind === "image" ? await handleImage(model, body) : await handleChat(model, body);
+  } catch (err) {
+    return bad(500, "proxy exception", String(err));
+  }
+});

--- a/supabase/functions/llm-proxy/index.ts
+++ b/supabase/functions/llm-proxy/index.ts
@@ -253,9 +253,7 @@ serve(async (req) => {
   if (!kind) return bad(origin, 400, `unsupported model "${model}"`);
 
   try {
-    return kind === "image"
-      ? await handleImage(origin, model, body)
-      : await handleChat(origin, model, body);
+    return kind === "image" ? await handleImage(origin, model, body) : await handleChat(origin, model, body);
   } catch (err) {
     return bad(origin, 500, "proxy exception", String(err));
   }

--- a/supabase/migrations/20260417_jobs.sql
+++ b/supabase/migrations/20260417_jobs.sql
@@ -1,0 +1,74 @@
+-- Jobs + job_events tables.
+--
+-- Replaces the in-memory AgentBridge._jobs dict so a cold-stopped Fly
+-- machine doesn't lose jobs between POST /generate and the SSE reconnect.
+--
+-- Run via `supabase db push` after `supabase link`. Idempotent.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists public.jobs (
+    id              text primary key,
+    status          text not null check (status in ('queued','running','succeeded','failed')),
+    prompt          text not null,
+    pages           text,
+    output_name     text not null default 'presentation.pptx',
+    models          jsonb not null default '{}'::jsonb,
+    attachments     jsonb not null default '[]'::jsonb,
+    workspace       text,
+    owner_sub       text,
+    created_at      timestamptz not null default now(),
+    started_at      timestamptz,
+    finished_at     timestamptz,
+    pptx_url        text,
+    error           text
+);
+
+create index if not exists jobs_owner_created_idx
+    on public.jobs (owner_sub, created_at desc);
+
+create index if not exists jobs_status_idx
+    on public.jobs (status)
+    where status in ('queued','running');
+
+create table if not exists public.job_events (
+    id              bigserial primary key,
+    job_id          text not null references public.jobs(id) on delete cascade,
+    seq             int  not null,
+    stage           text not null,
+    message         text not null,
+    percent         real,
+    slide_index     int,
+    slide_preview_url text,
+    pptx_url        text,
+    error           text,
+    created_at      timestamptz not null default now(),
+    unique (job_id, seq)
+);
+
+create index if not exists job_events_job_idx
+    on public.job_events (job_id, seq);
+
+-- Row-level security.
+alter table public.jobs        enable row level security;
+alter table public.job_events  enable row level security;
+
+-- Service role bypasses RLS by default, so FastAPI (running with the service
+-- role key) has full access. Authenticated users see only their own jobs.
+drop policy if exists "read own jobs" on public.jobs;
+create policy "read own jobs" on public.jobs
+    for select to authenticated
+    using (owner_sub = auth.jwt() ->> 'sub');
+
+drop policy if exists "read own job events" on public.job_events;
+create policy "read own job events" on public.job_events
+    for select to authenticated
+    using (
+        exists (
+            select 1 from public.jobs j
+            where j.id = job_events.job_id and j.owner_sub = auth.jwt() ->> 'sub'
+        )
+    );
+
+-- Enable Realtime so the frontend can optionally subscribe directly.
+alter publication supabase_realtime add table public.job_events;

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,0 +1,8 @@
+# Next.js frontend env. Copy to web/.env.local.
+
+# FastAPI origin (leave blank for same-origin /proxy rewrite in dev)
+NEXT_PUBLIC_API_ORIGIN=http://localhost:7870
+
+# Supabase (public values - safe for the browser)
+NEXT_PUBLIC_SUPABASE_URL=https://REPLACE.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+out
+.env.local
+.env.*.local
+.vercel
+*.log
+.DS_Store

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json ./
+RUN npm install --package-lock-only && npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,55 @@
+# PPTAgent Web (Next.js 14)
+
+Dribbble-grade frontend for PPTAgent. App Router, Tailwind, shadcn/ui primitives,
+Framer Motion, Zustand.
+
+## 디자인 시스템
+
+- **Palette**: Deep Space (`--ink-950`) 바탕, Electron Purple (`--electron`) 시그니처, Aurora (`--aurora`) 그린 보조, Sunrise (`--sunrise`) 웜 하이라이트
+- **Type**: Inter (본문), JetBrains Mono (데이터·이벤트 스트림). Satoshi 변수폰트를 외부 호스팅할 경우 `--font-satoshi` 를 덮어씁니다
+- **Surface**: Glassmorphism (`.glass`) + subtle noise (`.noise-layer`) + grid backdrop (`.grid-backdrop`)
+- **Motion**: Framer Motion · `cubic-bezier(0.22, 1, 0.36, 1)` easing · hover = `y: -1`, tap = `scale: 0.98`
+- **Layout**: Studio 는 3-pane (220px Rail / flex / 420px Preview)
+
+## 구조
+
+```
+app/
+  layout.tsx           Root shell (Inter + JetBrains Mono, Sonner toaster)
+  page.tsx             Landing hero + features + pipeline
+  studio/page.tsx      3-pane Studio editor
+components/
+  common/
+    GlassCard.tsx
+    MotionButton.tsx
+    NoiseBackground.tsx
+  studio/
+    StepRail.tsx       왼쪽 파이프라인 rail
+    PromptEditor.tsx   가운데 프롬프트 + 첨부 + 모델 선택
+    SlidePreview.tsx   오른쪽 실시간 슬라이드 + 이벤트 로그
+    ModelSelector.tsx  슬롯별 모델 드롭다운
+lib/
+  api.ts               FastAPI 클라이언트 (fetch + SSE + upload)
+  models.ts            Google 모델 카탈로그 + 슬롯 라벨 + 기본값
+  store.ts             Zustand 전역 스토어 (prompt · events · slides)
+  supabase.ts          브라우저용 Supabase 클라이언트
+  utils.ts             cn, formatBytes, clamp
+```
+
+## 로컬 실행
+
+```bash
+cd web
+cp .env.local.example .env.local   # API 주소 + Supabase 공개 키
+pnpm install   # 또는 npm install
+pnpm dev       # http://localhost:3000
+```
+
+`NEXT_PUBLIC_API_ORIGIN` 이 비어 있으면 `next.config.mjs` 의 rewrite 에 의해
+`/proxy/*` 가 `http://localhost:7870/*` 로 전달됩니다.
+
+## 접근성 메모
+
+- 모든 인터랙티브 요소는 `.focus-ring` 유틸로 `2px` electron ring 을 노출합니다.
+- `prefers-reduced-motion` 사용자를 위해 애니메이션은 opacity/transform 만 사용했습니다.
+- 색 대비는 WCAG AA (`--foreground` on `--background` ≥ 7:1).

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,163 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ---------------------------------------------------------------------------
+   Design tokens - Dribbble-inspired "Deep Space + Electron Purple" system
+   --------------------------------------------------------------------------- */
+@layer base {
+  :root {
+    /* Ink scale (neutral, charcoal-biased) */
+    --ink-50: 230 25% 96%;
+    --ink-100: 230 20% 91%;
+    --ink-200: 230 16% 82%;
+    --ink-300: 230 13% 66%;
+    --ink-400: 230 11% 50%;
+    --ink-500: 232 12% 34%;
+    --ink-600: 232 14% 22%;
+    --ink-700: 232 18% 15%;
+    --ink-800: 232 22% 10%;
+    --ink-900: 232 30% 7%;
+    --ink-950: 232 40% 4%;
+
+    /* Brand accents */
+    --electron: 258 96% 66%;       /* primary CTA */
+    --electron-soft: 258 100% 78%;
+    --electron-glow: 258 100% 72%;
+    --aurora: 168 72% 60%;         /* supporting gradient */
+    --sunrise: 26 96% 64%;         /* warm highlight */
+
+    /* Semantic (dark is the first-class mode) */
+    --background: 232 40% 4%;
+    --foreground: 230 25% 96%;
+    --card: 232 30% 7%;
+    --card-foreground: 230 25% 96%;
+    --muted: 232 22% 10%;
+    --muted-foreground: 230 13% 66%;
+    --border: 232 22% 14%;
+    --ring: 258 96% 66%;
+    --destructive: 358 76% 60%;
+    --radius: 16px;
+  }
+
+  .light {
+    --background: 230 30% 98%;
+    --foreground: 232 40% 6%;
+    --card: 0 0% 100%;
+    --card-foreground: 232 40% 6%;
+    --muted: 230 20% 95%;
+    --muted-foreground: 232 14% 40%;
+    --border: 230 20% 90%;
+    --ring: 258 96% 58%;
+    --destructive: 358 76% 50%;
+  }
+
+  html {
+    font-feature-settings: "ss01", "cv11", "calt";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(60% 60% at 20% 0%, hsl(var(--electron-glow) / 0.15) 0%, transparent 60%),
+      radial-gradient(50% 50% at 100% 20%, hsl(var(--aurora) / 0.12) 0%, transparent 60%),
+      radial-gradient(40% 40% at 50% 100%, hsl(var(--sunrise) / 0.08) 0%, transparent 60%);
+    min-height: 100vh;
+  }
+
+  ::selection {
+    background-color: hsl(var(--electron) / 0.35);
+    color: hsl(var(--foreground));
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Component-level utilities used across the studio
+   --------------------------------------------------------------------------- */
+@layer components {
+  .glass {
+    background: linear-gradient(
+        180deg,
+        hsl(var(--card) / 0.8) 0%,
+        hsl(var(--card) / 0.6) 100%
+      ),
+      radial-gradient(
+        circle at top left,
+        hsl(var(--electron) / 0.08),
+        transparent 60%
+      );
+    backdrop-filter: blur(22px) saturate(140%);
+    -webkit-backdrop-filter: blur(22px) saturate(140%);
+    border: 1px solid hsl(var(--border));
+    box-shadow: var(--tw-shadow, 0 0 0 transparent), inset 0 1px 0 hsl(0 0% 100% / 0.04);
+  }
+
+  .noise-layer {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.35;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.25'/></svg>");
+  }
+
+  .grid-backdrop {
+    background-image: linear-gradient(hsl(var(--border)) 1px, transparent 1px),
+      linear-gradient(90deg, hsl(var(--border)) 1px, transparent 1px);
+    background-size: 24px 24px;
+    mask-image: radial-gradient(ellipse at center, black 45%, transparent 80%);
+  }
+
+  .tag {
+    @apply inline-flex items-center gap-1 rounded-full border border-border/80
+           bg-muted/60 px-2.5 py-1 text-xs font-medium text-muted-foreground;
+  }
+
+  .soft-divider {
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      hsl(var(--border)) 30%,
+      hsl(var(--border)) 70%,
+      transparent
+    );
+  }
+
+  .focus-ring {
+    @apply focus-visible:outline-none focus-visible:ring-2
+           focus-visible:ring-electron focus-visible:ring-offset-2
+           focus-visible:ring-offset-background;
+  }
+}
+
+@layer utilities {
+  .text-gradient {
+    background: linear-gradient(
+      120deg,
+      hsl(var(--foreground)) 0%,
+      hsl(var(--electron-soft)) 40%,
+      hsl(var(--aurora)) 80%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  .scrollbar-slim::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  .scrollbar-slim::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollbar-slim::-webkit-scrollbar-thumb {
+    background: hsl(var(--border));
+    border-radius: 999px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+}

--- a/web/app/icon.svg
+++ b/web/app/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#7C5CFF" />
+      <stop offset="100%" stop-color="#5AE0BD" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#05050E" />
+  <path d="M20 46 L20 18 L32 18 C40 18 44 22 44 28 C44 34 40 38 32 38 L26 38 L26 46 Z M26 32 L32 32 C36 32 38 30 38 28 C38 26 36 24 32 24 L26 24 Z" fill="url(#g)" />
+</svg>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,74 @@
+import "./globals.css";
+
+import type { Metadata, Viewport } from "next";
+import { Inter, JetBrains_Mono } from "next/font/google";
+import { Toaster } from "sonner";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+const jetbrains = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-jetbrains",
+  display: "swap",
+});
+
+export const metadata: Metadata = {
+  title: {
+    default: "PPTAgent Studio",
+    template: "%s · PPTAgent Studio",
+  },
+  description:
+    "Prompt-to-deck studio powered by PPTAgent. Deep research, free-form visual design, and agentic slide generation - wrapped in a Dribbble-grade interface.",
+  applicationName: "PPTAgent Studio",
+  keywords: [
+    "PPT",
+    "PowerPoint",
+    "AI",
+    "Gemini",
+    "Imagen",
+    "Agent",
+    "Slide Generation",
+    "Supabase",
+  ],
+  authors: [{ name: "PPTAgent" }],
+  openGraph: {
+    type: "website",
+    title: "PPTAgent Studio",
+    description: "AI-native presentation studio on top of PPTAgent.",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: dark)", color: "#06060c" },
+    { media: "(prefers-color-scheme: light)", color: "#f6f7fb" },
+  ],
+  width: "device-width",
+  initialScale: 1,
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ko" className={`${inter.variable} ${jetbrains.variable}`} suppressHydrationWarning>
+      <body className="font-sans antialiased">
+        {children}
+        <Toaster
+          theme="dark"
+          position="top-right"
+          toastOptions={{
+            className:
+              "!bg-card !text-foreground !border !border-border/70 !shadow-glass backdrop-blur-xl",
+          }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,181 @@
+import Link from "next/link";
+import { ArrowUpRight, Sparkles, Wand2, LayoutTemplate, Image as ImageIcon, Rocket } from "lucide-react";
+
+import { GlassCard } from "@/components/common/GlassCard";
+import { MotionButton } from "@/components/common/MotionButton";
+import { NoiseBackground } from "@/components/common/NoiseBackground";
+
+export default function HomePage() {
+  return (
+    <main className="relative min-h-screen">
+      <NoiseBackground />
+
+      {/* Top nav */}
+      <header className="container flex h-20 items-center justify-between">
+        <Link href="/" className="flex items-center gap-2 font-semibold tracking-tight">
+          <span className="relative flex h-9 w-9 items-center justify-center rounded-xl bg-electron/20 text-electron">
+            <span className="absolute inset-0 rounded-xl bg-electron/40 blur-xl" />
+            <Sparkles className="relative h-4 w-4" />
+          </span>
+          PPTAgent Studio
+        </Link>
+
+        <nav className="hidden items-center gap-6 text-sm text-muted-foreground md:flex">
+          <a href="#features" className="transition hover:text-foreground">기능</a>
+          <a href="#pipeline" className="transition hover:text-foreground">파이프라인</a>
+          <a href="https://github.com/icip-cas/PPTAgent" className="transition hover:text-foreground">GitHub</a>
+        </nav>
+        <Link href="/studio">
+          <MotionButton size="sm" iconRight={<ArrowUpRight className="h-4 w-4" />}>Studio 시작</MotionButton>
+        </Link>
+      </header>
+
+      {/* Hero */}
+      <section className="container pt-10 pb-24 md:pt-24">
+        <div className="mx-auto max-w-5xl text-center">
+          <span className="tag mx-auto animate-fade-up">
+            <span className="h-1.5 w-1.5 rounded-full bg-aurora animate-breathing" />
+            Multi-agent · Deep Research · Free-form Design
+          </span>
+
+          <h1 className="mt-6 font-display text-display-md leading-[1.02] tracking-[-0.035em] md:text-display-xl">
+            <span className="text-gradient">프롬프트 한 줄</span>로<br />
+            발표 자료 전체를 설계합니다.
+          </h1>
+
+          <p className="mx-auto mt-8 max-w-2xl text-balance text-lg text-muted-foreground">
+            PPTAgent 의 멀티 에이전트 루프에 Dribbble 수준의 인터페이스를 얹었습니다.
+            Google Imagen 이 커버를, Gemini 가 구조를 맡고, Supabase Edge Function 이
+            API 키를 안전하게 보관합니다.
+          </p>
+
+          <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Link href="/studio">
+              <MotionButton size="lg" iconRight={<Wand2 className="h-4 w-4" />}>
+                지금 만들어보기
+              </MotionButton>
+            </Link>
+            <a href="#pipeline" className="text-sm text-muted-foreground underline-offset-4 hover:underline">
+              작동 방식 보기 →
+            </a>
+          </div>
+        </div>
+
+        {/* Hero card preview */}
+        <div className="relative mx-auto mt-20 max-w-6xl">
+          <div className="pointer-events-none absolute inset-x-0 -top-10 mx-auto h-64 w-3/4 rounded-full bg-electron/25 blur-3xl" />
+          <GlassCard elevated className="p-0">
+            <div className="grid gap-0 md:grid-cols-[280px_1fr_340px]">
+              <div className="border-b border-border/60 p-5 md:border-b-0 md:border-r">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">1 · Research</p>
+                <p className="mt-3 font-medium">자료 수집 · 문맥 이해</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  PDF·XLSX·Markdown 을 MinerU 로 파싱하고 개요를 구성합니다.
+                </p>
+              </div>
+              <div className="border-b border-border/60 p-5 md:border-b-0 md:border-r">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">2 · Design</p>
+                <p className="mt-3 font-medium">HTML 기반 자유형 레이아웃</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Gemini 2.5 Pro 가 슬라이드 HTML 을 직접 설계하고 피드백 루프를 돕니다.
+                </p>
+              </div>
+              <div className="p-5">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">3 · Export</p>
+                <p className="mt-3 font-medium">PPTX · Supabase Storage</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  브라우저 렌더 후 html2pptx 로 네이티브 PPTX 를 생성, 서명된 URL 로 즉시 공유.
+                </p>
+              </div>
+            </div>
+          </GlassCard>
+        </div>
+      </section>
+
+      {/* Features grid */}
+      <section id="features" className="container py-24">
+        <div className="max-w-2xl">
+          <p className="tag">Design System</p>
+          <h2 className="mt-4 font-display text-display-sm tracking-[-0.02em]">
+            발표 자료를 만드는, <span className="text-gradient">가장 미려한 도구</span>.
+          </h2>
+          <p className="mt-4 text-muted-foreground">
+            3-pane Creative Suite 레이아웃, Deep Space 팔레트, 퍼플 글로우. 모든 디테일이
+            Dribbble 1차 피드의 기준에 맞춰 정돈돼 있습니다.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-4 md:grid-cols-3">
+          <GlassCard interactive>
+            <LayoutTemplate className="h-5 w-5 text-electron" />
+            <h3 className="mt-5 text-lg font-semibold">3-pane Studio</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              좌측 Step Rail · 중앙 Prompt Editor · 우측 실시간 Slide Preview. 어떤 단계든
+              문맥 이탈 없이 이동할 수 있습니다.
+            </p>
+          </GlassCard>
+          <GlassCard interactive>
+            <ImageIcon className="h-5 w-5 text-aurora" />
+            <h3 className="mt-5 text-lg font-semibold">Imagen-first</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              기본 이미지 생성은 Google Imagen 3. 드롭다운에서 Gemini 2.0/2.5 계열로
+              언제든 교체 가능합니다.
+            </p>
+          </GlassCard>
+          <GlassCard interactive>
+            <Rocket className="h-5 w-5 text-sunrise" />
+            <h3 className="mt-5 text-lg font-semibold">Supabase Edge 프록시</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Google API 키는 Edge Function Secret 에만 존재합니다. 프론트·FastAPI 는
+              키를 절대 보지 못합니다.
+            </p>
+          </GlassCard>
+        </div>
+      </section>
+
+      {/* Pipeline diagram */}
+      <section id="pipeline" className="container py-24">
+        <GlassCard elevated className="overflow-hidden">
+          <div className="grid gap-8 md:grid-cols-[1.1fr_1fr]">
+            <div>
+              <p className="tag">Pipeline</p>
+              <h2 className="mt-4 font-display text-display-sm tracking-[-0.02em]">
+                브라우저에서 PPTX 까지.
+              </h2>
+              <p className="mt-4 text-muted-foreground">
+                Next.js 가 프롬프트와 모델 선택을 FastAPI 에 전달하면, FastAPI 는 Docker
+                샌드박스 안의 PPTAgent AgentLoop 를 실행합니다. 모든 LLM 호출은 Supabase
+                Edge Function 을 거쳐 Google 로 향하고, 결과 PPTX 는 Supabase Storage 의
+                서명된 URL 로 즉시 다운로드할 수 있습니다.
+              </p>
+            </div>
+            <div className="relative isolate">
+              <pre className="overflow-x-auto rounded-2xl bg-ink-900/70 p-5 text-xs leading-relaxed text-muted-foreground">
+{`Next.js  ── REST ─▶  FastAPI ── spawn ─▶  AgentLoop (Docker)
+   ▲                     │
+   │                     ▼
+   └── SSE ◀── events ── WSL2 host
+                        │
+                        ▼
+           ┌──────────────────────┐
+           │ Supabase Edge Fn     │
+           │ llm-proxy (Deno)     │
+           │  ├─ Gemini chat/vis  │
+           │  └─ Imagen T2I       │
+           └──────────────────────┘`}
+              </pre>
+            </div>
+          </div>
+        </GlassCard>
+      </section>
+
+      <footer className="container flex flex-col items-start justify-between gap-6 border-t border-border/60 py-10 text-sm text-muted-foreground md:flex-row md:items-center">
+        <p>© 2026 PPTAgent Studio · built on icip-cas/PPTAgent</p>
+        <div className="flex gap-5">
+          <a href="https://github.com/icip-cas/PPTAgent" className="hover:text-foreground">GitHub</a>
+          <a href="/studio" className="hover:text-foreground">Studio</a>
+        </div>
+      </footer>
+    </main>
+  );
+}

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Sparkles } from "lucide-react";
+
+import { NoiseBackground } from "@/components/common/NoiseBackground";
+import { PromptEditor } from "@/components/studio/PromptEditor";
+import { SlidePreview } from "@/components/studio/SlidePreview";
+import { StepRail } from "@/components/studio/StepRail";
+
+export const metadata: Metadata = {
+  title: "Studio",
+  description: "PPTAgent Studio - prompt, model routing, and live slide preview.",
+};
+
+export default function StudioPage() {
+  return (
+    <main className="relative min-h-screen">
+      <NoiseBackground />
+
+      <header className="flex items-center justify-between border-b border-border/60 bg-card/40 px-6 py-3 backdrop-blur-xl">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/"
+            className="focus-ring flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-muted/40 transition hover:border-electron/40"
+            aria-label="뒤로"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <div className="flex items-center gap-2 text-sm font-semibold">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-electron/20 text-electron">
+              <Sparkles className="h-3.5 w-3.5" />
+            </span>
+            Studio
+          </div>
+        </div>
+        <div className="hidden items-center gap-5 text-xs text-muted-foreground md:flex">
+          <span>Model routing · Google Imagen / Gemini via Supabase Edge</span>
+        </div>
+      </header>
+
+      <div className="grid h-[calc(100vh-57px)] grid-cols-[auto_1fr_auto] overflow-hidden">
+        <StepRail />
+        <PromptEditor />
+        <SlidePreview />
+      </div>
+    </main>
+  );
+}

--- a/web/app/studio/page.tsx
+++ b/web/app/studio/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowLeft, Sparkles } from "lucide-react";
 
 import { NoiseBackground } from "@/components/common/NoiseBackground";
+import { ConnectionBadge } from "@/components/studio/ConnectionBadge";
 import { PromptEditor } from "@/components/studio/PromptEditor";
 import { SlidePreview } from "@/components/studio/SlidePreview";
 import { StepRail } from "@/components/studio/StepRail";
@@ -33,8 +34,9 @@ export default function StudioPage() {
             Studio
           </div>
         </div>
-        <div className="hidden items-center gap-5 text-xs text-muted-foreground md:flex">
+        <div className="hidden items-center gap-3 text-xs text-muted-foreground md:flex">
           <span>Model routing · Google Imagen / Gemini via Supabase Edge</span>
+          <ConnectionBadge />
         </div>
       </header>
 

--- a/web/components/common/GlassCard.tsx
+++ b/web/components/common/GlassCard.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { forwardRef, type HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+type GlassCardProps = HTMLAttributes<HTMLDivElement> & {
+  /** Adds a soft purple halo glow on hover. */
+  interactive?: boolean;
+  /** Uses a heavier blur/inset shadow - good for hero panels. */
+  elevated?: boolean;
+};
+
+export const GlassCard = forwardRef<HTMLDivElement, GlassCardProps>(
+  ({ className, interactive, elevated, children, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "glass relative rounded-3xl p-6 transition",
+          elevated ? "shadow-glass" : "shadow-soft",
+          interactive &&
+            "cursor-pointer hover:-translate-y-0.5 hover:shadow-halo hover:border-electron/40",
+          className,
+        )}
+        {...rest}
+      >
+        <span className="noise-layer rounded-[inherit]" aria-hidden />
+        {children}
+      </div>
+    );
+  },
+);
+
+GlassCard.displayName = "GlassCard";

--- a/web/components/common/MotionButton.tsx
+++ b/web/components/common/MotionButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { motion, type HTMLMotionProps } from "framer-motion";
+import { forwardRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+type Variant = "primary" | "secondary" | "ghost";
+
+type MotionButtonProps = HTMLMotionProps<"button"> & {
+  variant?: Variant;
+  size?: "sm" | "md" | "lg";
+  iconLeft?: React.ReactNode;
+  iconRight?: React.ReactNode;
+};
+
+const variantClass: Record<Variant, string> = {
+  primary:
+    "bg-[linear-gradient(135deg,hsl(var(--electron))_0%,hsl(var(--electron-glow))_100%)] text-white shadow-halo hover:brightness-[1.05]",
+  secondary:
+    "bg-card text-foreground border border-border hover:border-electron/50 hover:bg-muted",
+  ghost: "bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted/60",
+};
+
+const sizeClass = {
+  sm: "h-9 px-3.5 text-sm",
+  md: "h-11 px-5 text-sm",
+  lg: "h-14 px-7 text-base",
+};
+
+export const MotionButton = forwardRef<HTMLButtonElement, MotionButtonProps>(
+  (
+    { className, variant = "primary", size = "md", iconLeft, iconRight, children, ...rest },
+    ref,
+  ) => {
+    return (
+      <motion.button
+        ref={ref}
+        whileHover={{ y: -1 }}
+        whileTap={{ scale: 0.98 }}
+        transition={{ type: "spring", stiffness: 420, damping: 28 }}
+        className={cn(
+          "focus-ring inline-flex items-center justify-center gap-2 rounded-2xl font-semibold tracking-tight transition",
+          variantClass[variant],
+          sizeClass[size],
+          className,
+        )}
+        {...rest}
+      >
+        {iconLeft}
+        <span className="min-w-0 truncate">{children}</span>
+        {iconRight}
+      </motion.button>
+    );
+  },
+);
+
+MotionButton.displayName = "MotionButton";

--- a/web/components/common/MotionButton.tsx
+++ b/web/components/common/MotionButton.tsx
@@ -7,11 +7,12 @@ import { cn } from "@/lib/utils";
 
 type Variant = "primary" | "secondary" | "ghost";
 
-type MotionButtonProps = HTMLMotionProps<"button"> & {
+type MotionButtonProps = Omit<HTMLMotionProps<"button">, "children"> & {
   variant?: Variant;
   size?: "sm" | "md" | "lg";
   iconLeft?: React.ReactNode;
   iconRight?: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 const variantClass: Record<Variant, string> = {

--- a/web/components/common/NoiseBackground.tsx
+++ b/web/components/common/NoiseBackground.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+/**
+ * Ambient background: soft aurora mesh + slow-breathing particles + faint
+ * grid. Rendered once at the root of full-screen pages. All animations use
+ * transform/opacity only so the main thread stays clear.
+ */
+export function NoiseBackground() {
+  return (
+    <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+      <div className="absolute inset-0 grid-backdrop opacity-40" />
+      <motion.div
+        className="absolute -top-40 left-1/2 h-[720px] w-[1200px] -translate-x-1/2 rounded-full bg-electron/25 blur-3xl"
+        animate={{ opacity: [0.55, 0.8, 0.55], scale: [1, 1.04, 1] }}
+        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }}
+      />
+      <motion.div
+        className="absolute bottom-[-220px] right-[-80px] h-[520px] w-[520px] rounded-full bg-aurora/20 blur-3xl"
+        animate={{ opacity: [0.45, 0.7, 0.45], x: [0, 20, 0] }}
+        transition={{ duration: 11, repeat: Infinity, ease: "easeInOut", delay: 0.8 }}
+      />
+      <motion.div
+        className="absolute top-1/3 left-[-140px] h-[360px] w-[360px] rounded-full bg-sunrise/18 blur-3xl"
+        animate={{ opacity: [0.3, 0.55, 0.3], y: [0, -16, 0] }}
+        transition={{ duration: 13, repeat: Infinity, ease: "easeInOut", delay: 1.6 }}
+      />
+      <div className="noise-layer" />
+    </div>
+  );
+}

--- a/web/components/studio/ConnectionBadge.tsx
+++ b/web/components/studio/ConnectionBadge.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { Cloud, CloudOff, Loader2 } from "lucide-react";
+
+import { isApiReachable } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type Status = "checking" | "live" | "demo";
+
+const LABEL: Record<Status, string> = {
+  checking: "연결 확인 중",
+  live: "API 연결됨",
+  demo: "데모 모드",
+};
+
+const HINT: Record<Status, string> = {
+  checking: "헬스체크 중입니다.",
+  live: "FastAPI · Supabase · Google 모델이 모두 연결된 상태입니다.",
+  demo: "FastAPI 가 아직 배포되지 않아 샘플 데이터로 미리 보기 중입니다. " +
+    "NEXT_PUBLIC_API_ORIGIN 시크릿 등록 + 백엔드 배포 후 자동 전환됩니다.",
+};
+
+export function ConnectionBadge() {
+  const [status, setStatus] = useState<Status>("checking");
+
+  useEffect(() => {
+    let alive = true;
+    isApiReachable().then((ok) => {
+      if (alive) setStatus(ok ? "live" : "demo");
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const Icon = status === "checking" ? Loader2 : status === "live" ? Cloud : CloudOff;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -4 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={cn(
+        "group relative hidden items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium md:inline-flex",
+        status === "live"
+          ? "border-aurora/50 bg-aurora/10 text-aurora"
+          : status === "demo"
+            ? "border-sunrise/40 bg-sunrise/10 text-sunrise"
+            : "border-border/60 bg-muted/50 text-muted-foreground",
+      )}
+      title={HINT[status]}
+    >
+      <Icon className={cn("h-3.5 w-3.5", status === "checking" && "animate-spin")} />
+      {LABEL[status]}
+      <span className="absolute right-0 top-[calc(100%+6px)] hidden w-64 rounded-xl border border-border/60 bg-card/90 p-3 text-[11px] leading-relaxed text-muted-foreground shadow-glass backdrop-blur-xl group-hover:block">
+        {HINT[status]}
+      </span>
+    </motion.div>
+  );
+}

--- a/web/components/studio/ModelSelector.tsx
+++ b/web/components/studio/ModelSelector.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+
+import {
+  GOOGLE_MODELS,
+  MODEL_SLOT_HINT,
+  MODEL_SLOT_LABEL,
+  optionsForSlot,
+  type ModelSlot,
+} from "@/lib/models";
+import { cn } from "@/lib/utils";
+import { useStudioStore } from "@/lib/store";
+
+const SLOTS: ModelSlot[] = [
+  "research_agent",
+  "design_agent",
+  "long_context_model",
+  "vision_model",
+  "t2i_model",
+];
+
+export function ModelSelector() {
+  const overrides = useStudioStore((s) => s.overrides);
+  const setModel = useStudioStore((s) => s.setModel);
+
+  return (
+    <div className="space-y-2.5">
+      <p className="text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+        Model routing
+      </p>
+      <div className="grid gap-2">
+        {SLOTS.map((slot) => (
+          <SlotRow key={slot} slot={slot} value={overrides[slot] ?? ""} onChange={(v) => setModel(slot, v)} />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        기본값은 <span className="font-semibold text-foreground">Google Imagen</span> (T2I) ·{" "}
+        <span className="font-semibold text-foreground">Gemini 2.5 Pro</span> (Design). 언제든 변경할 수 있습니다.
+      </p>
+    </div>
+  );
+}
+
+function SlotRow({
+  slot,
+  value,
+  onChange,
+}: {
+  slot: ModelSlot;
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const options = optionsForSlot(slot);
+  const active = GOOGLE_MODELS.find((m) => m.id === value) ?? options[0];
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="focus-ring group flex w-full items-center justify-between gap-3 rounded-xl border border-border/70 bg-muted/40 px-3.5 py-2.5 text-left transition hover:border-electron/40 hover:bg-muted/60"
+      >
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            {MODEL_SLOT_LABEL[slot]}
+          </p>
+          <p className="mt-1 truncate text-sm font-medium">{active?.label ?? "—"}</p>
+        </div>
+        <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground transition group-hover:text-foreground" />
+      </button>
+
+      {open && (
+        <div className="glass absolute left-0 right-0 top-[calc(100%+6px)] z-40 space-y-1 rounded-2xl p-1.5 shadow-halo">
+          {options.map((opt) => {
+            const selected = opt.id === active?.id;
+            return (
+              <button
+                key={opt.id}
+                onClick={() => {
+                  onChange(opt.id);
+                  setOpen(false);
+                }}
+                className={cn(
+                  "flex w-full items-start gap-2.5 rounded-xl px-2.5 py-2 text-left transition hover:bg-muted/60",
+                  selected && "bg-electron/10",
+                )}
+              >
+                <span
+                  className={cn(
+                    "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border",
+                    selected ? "border-electron bg-electron text-background" : "border-border",
+                  )}
+                >
+                  {selected && <Check className="h-3 w-3" />}
+                </span>
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium">{opt.label}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {opt.notes ?? MODEL_SLOT_HINT[slot]}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/studio/PromptEditor.tsx
+++ b/web/components/studio/PromptEditor.tsx
@@ -9,7 +9,8 @@ import { toast } from "sonner";
 import { MotionButton } from "@/components/common/MotionButton";
 import { ModelSelector } from "@/components/studio/ModelSelector";
 import { useStudioStore } from "@/lib/store";
-import { createJob, streamEvents, uploadAttachment } from "@/lib/api";
+import { createJob, isApiReachable, streamEvents, uploadAttachment } from "@/lib/api";
+import { createDemoJob, runDemoJob } from "@/lib/demo";
 import { cn, formatBytes } from "@/lib/utils";
 
 const PROMPT_SUGGESTIONS = [
@@ -64,6 +65,32 @@ export function PromptEditor() {
       return;
     }
     setSubmitting(true);
+
+    // Probe the backend. If unreachable, run the demo event stream so the UI
+    // still tells a complete story (reviewers can evaluate the design without
+    // the FastAPI/Fly deployment being live).
+    const apiOk = await isApiReachable();
+
+    if (!apiOk) {
+      toast.message("데모 모드로 진행합니다", {
+        description: "FastAPI 백엔드가 아직 연결되지 않아 샘플 슬라이드로 시뮬레이션합니다.",
+      });
+      const demo = createDemoJob(prompt.trim());
+      setJob(demo);
+      try {
+        await runDemoJob({
+          prompt: prompt.trim(),
+          onEvent: (ev) => {
+            appendEvent(ev);
+            if (ev.stage === "done") toast.success("데모 스트림 완료");
+          },
+        });
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
+
     try {
       const created = await createJob({
         prompt: prompt.trim(),

--- a/web/components/studio/PromptEditor.tsx
+++ b/web/components/studio/PromptEditor.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useDropzone } from "react-dropzone";
+import { FileText, Paperclip, Play, Sparkles, X } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { toast } from "sonner";
+
+import { MotionButton } from "@/components/common/MotionButton";
+import { ModelSelector } from "@/components/studio/ModelSelector";
+import { useStudioStore } from "@/lib/store";
+import { createJob, streamEvents, uploadAttachment } from "@/lib/api";
+import { cn, formatBytes } from "@/lib/utils";
+
+const PROMPT_SUGGESTIONS = [
+  "AI 스타트업 투자 유치용 10장짜리 피치덱",
+  "고등학생을 위한 기후변화 수업 슬라이드",
+  "Q2 프로덕트 OKR 리뷰 (차트 2개 포함)",
+];
+
+export function PromptEditor() {
+  const prompt = useStudioStore((s) => s.prompt);
+  const setPrompt = useStudioStore((s) => s.setPrompt);
+  const attachments = useStudioStore((s) => s.attachments);
+  const addAttachment = useStudioStore((s) => s.addAttachment);
+  const removeAttachment = useStudioStore((s) => s.removeAttachment);
+  const setJob = useStudioStore((s) => s.setJob);
+  const appendEvent = useStudioStore((s) => s.appendEvent);
+  const overrides = useStudioStore((s) => s.overrides);
+  const pages = useStudioStore((s) => s.pages);
+  const setPages = useStudioStore((s) => s.setPages);
+  const job = useStudioStore((s) => s.job);
+
+  const [submitting, setSubmitting] = useState(false);
+
+  const onDrop = useCallback(
+    async (files: File[]) => {
+      for (const file of files) {
+        try {
+          const result = await uploadAttachment(file);
+          addAttachment({
+            name: file.name,
+            objectPath: result.object_path,
+            size: file.size,
+          });
+        } catch (err) {
+          toast.error(`업로드 실패: ${file.name}`);
+          console.error(err);
+        }
+      }
+    },
+    [addAttachment],
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: true,
+    maxSize: 50 * 1024 * 1024,
+  });
+
+  async function handleGenerate() {
+    if (prompt.trim().length < 2) {
+      toast.error("프롬프트를 입력해 주세요.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const created = await createJob({
+        prompt: prompt.trim(),
+        attachments: attachments.map((a) => a.objectPath),
+        pages: pages || undefined,
+        models: overrides,
+        output_name: `pptagent-${Date.now()}.pptx`,
+      });
+      setJob(created);
+      streamEvents(
+        created.job_id,
+        (ev) => {
+          appendEvent(ev);
+          if (ev.stage === "error") toast.error(ev.error ?? ev.message);
+          if (ev.stage === "done") toast.success("PPTX 생성 완료!");
+        },
+        (err) => {
+          console.error(err);
+          toast.error("이벤트 스트림 연결이 끊어졌습니다.");
+        },
+      );
+    } catch (err) {
+      console.error(err);
+      toast.error("생성 요청에 실패했습니다. API 서버 상태를 확인해 주세요.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto scrollbar-slim p-8">
+      <header>
+        <span className="tag">
+          <Sparkles className="h-3 w-3 text-electron" />
+          프롬프트 & 설정
+        </span>
+        <h1 className="mt-3 font-display text-3xl font-semibold tracking-[-0.02em]">
+          어떤 발표 자료가 필요하신가요?
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          원하는 주제와 분량, 톤을 자유롭게 적어주세요. PDF·XLSX·이미지를 드래그해 첨부하면
+          본문에 포함됩니다.
+        </p>
+      </header>
+
+      <div className="glass relative rounded-3xl p-5">
+        <span className="noise-layer rounded-[inherit]" />
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="예: Q2 프로덕트 OKR 리뷰를 CTO 보고용으로 10장, 표지 1장 포함, 영문 30% 혼용"
+          rows={6}
+          className="relative block w-full resize-none border-0 bg-transparent font-sans text-base leading-relaxed text-foreground placeholder:text-muted-foreground focus:outline-none"
+        />
+        <div className="relative mt-2 flex flex-wrap gap-2">
+          {PROMPT_SUGGESTIONS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setPrompt(s)}
+              className="tag hover:border-electron/40 hover:text-foreground"
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div
+        {...getRootProps()}
+        className={cn(
+          "glass relative flex min-h-[120px] cursor-pointer flex-col items-center justify-center rounded-3xl border border-dashed border-border/70 p-5 text-center text-sm text-muted-foreground transition",
+          isDragActive && "border-electron bg-electron/5 text-foreground",
+        )}
+      >
+        <input {...getInputProps()} />
+        <Paperclip className="mb-2 h-5 w-5" />
+        {isDragActive ? "놓으면 업로드됩니다" : "PDF · DOCX · XLSX · 이미지 · 마크다운을 드롭하거나 클릭"}
+      </div>
+
+      <AnimatePresence>
+        {attachments.length > 0 && (
+          <motion.ul
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            className="grid gap-2 md:grid-cols-2"
+          >
+            {attachments.map((a) => (
+              <li
+                key={a.objectPath}
+                className="flex items-center gap-3 rounded-2xl border border-border/60 bg-muted/40 px-3 py-2.5"
+              >
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{a.name}</p>
+                  <p className="text-xs text-muted-foreground">{formatBytes(a.size)}</p>
+                </div>
+                <button
+                  onClick={() => removeAttachment(a.objectPath)}
+                  className="rounded-full p-1 text-muted-foreground transition hover:bg-background hover:text-foreground"
+                  aria-label="제거"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+
+      <div className="grid gap-2 md:grid-cols-[160px_1fr]">
+        <label className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground md:self-center">
+          PDF 페이지 범위
+        </label>
+        <input
+          value={pages ?? ""}
+          onChange={(e) => setPages(e.target.value || null)}
+          placeholder="예: 10-12 (비워두면 전체)"
+          className="focus-ring rounded-xl border border-border/60 bg-muted/40 px-3.5 py-2.5 text-sm placeholder:text-muted-foreground"
+        />
+      </div>
+
+      <ModelSelector />
+
+      <div className="mt-2 flex items-center justify-end gap-3">
+        <span className="text-xs text-muted-foreground">
+          {job ? `Job ${job.job_id}` : "Ready"}
+        </span>
+        <MotionButton
+          onClick={handleGenerate}
+          size="lg"
+          disabled={submitting || !!job}
+          iconLeft={<Play className="h-4 w-4" />}
+        >
+          {submitting ? "생성 중..." : "PPT 만들기"}
+        </MotionButton>
+      </div>
+    </section>
+  );
+}

--- a/web/components/studio/PromptEditor.tsx
+++ b/web/components/studio/PromptEditor.tsx
@@ -96,6 +96,7 @@ export function PromptEditor() {
       try {
         await runDemoJob({
           prompt: prompt.trim(),
+          jobId: demo.job_id,
           onEvent: (ev) => {
             appendEvent(ev);
             if (ev.stage === "done") toast.success("데모 스트림 완료");

--- a/web/components/studio/PromptEditor.tsx
+++ b/web/components/studio/PromptEditor.tsx
@@ -36,7 +36,18 @@ export function PromptEditor() {
 
   const onDrop = useCallback(
     async (files: File[]) => {
+      const apiOk = await isApiReachable();
       for (const file of files) {
+        if (!apiOk) {
+          // Demo mode: record the attachment client-side only. The real
+          // upload needs FastAPI + Supabase Storage, which aren't online yet.
+          addAttachment({
+            name: file.name,
+            objectPath: `demo/${file.name}`,
+            size: file.size,
+          });
+          continue;
+        }
         try {
           const result = await uploadAttachment(file);
           addAttachment({
@@ -48,6 +59,11 @@ export function PromptEditor() {
           toast.error(`업로드 실패: ${file.name}`);
           console.error(err);
         }
+      }
+      if (!apiOk && files.length > 0) {
+        toast.message("데모 모드 · 첨부 파일은 기록만 됩니다", {
+          description: "실제 파싱은 FastAPI 가 연결된 뒤 수행됩니다.",
+        });
       }
     },
     [addAttachment],

--- a/web/components/studio/SlidePreview.tsx
+++ b/web/components/studio/SlidePreview.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { Download, Monitor, Radio } from "lucide-react";
+
+import { MotionButton } from "@/components/common/MotionButton";
+import { useStudioStore } from "@/lib/store";
+import { cn } from "@/lib/utils";
+
+export function SlidePreview() {
+  const slides = useStudioStore((s) => s.slides);
+  const active = useStudioStore((s) => s.activeSlide);
+  const setActive = useStudioStore((s) => s.setActiveSlide);
+  const events = useStudioStore((s) => s.events);
+  const pptxUrl = useStudioStore((s) => s.pptxUrl);
+  const job = useStudioStore((s) => s.job);
+
+  const hasSlides = slides.length > 0;
+  const currentSlide = hasSlides ? slides[active] ?? slides[0] : null;
+  const latestEvent = events.at(-1);
+
+  return (
+    <aside className="flex h-full w-[420px] shrink-0 flex-col border-l border-border/60 bg-card/40 backdrop-blur-xl">
+      <header className="flex items-center justify-between border-b border-border/60 px-5 py-4">
+        <div className="flex items-center gap-2">
+          <Monitor className="h-4 w-4 text-electron" />
+          <p className="text-sm font-semibold">실시간 프리뷰</p>
+        </div>
+        {pptxUrl && (
+          <a href={pptxUrl} target="_blank" rel="noreferrer">
+            <MotionButton size="sm" variant="secondary" iconLeft={<Download className="h-3.5 w-3.5" />}>
+              PPTX
+            </MotionButton>
+          </a>
+        )}
+      </header>
+
+      <div className="flex flex-1 flex-col gap-4 overflow-y-auto scrollbar-slim p-5">
+        <div className="glass relative aspect-video overflow-hidden rounded-2xl">
+          <AnimatePresence mode="wait">
+            {currentSlide?.imageUrl ? (
+              <motion.img
+                key={currentSlide.imageUrl}
+                src={currentSlide.imageUrl}
+                alt={currentSlide.title ?? `Slide ${currentSlide.index + 1}`}
+                className="absolute inset-0 h-full w-full object-cover"
+                initial={{ opacity: 0, scale: 1.02 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.98 }}
+                transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+              />
+            ) : (
+              <motion.div
+                key="placeholder"
+                className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-center text-muted-foreground"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted/60">
+                  <Radio className="h-4 w-4 animate-breathing text-electron" />
+                </div>
+                <p className="text-sm font-medium">
+                  {job ? "슬라이드가 곧 표시됩니다" : "Prompt 실행 대기 중"}
+                </p>
+                {latestEvent && (
+                  <p className="max-w-[80%] text-xs leading-relaxed text-muted-foreground/80">
+                    {latestEvent.message}
+                  </p>
+                )}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: Math.max(slides.length, 6) }).map((_, i) => {
+            const s = slides[i];
+            return (
+              <button
+                key={i}
+                onClick={() => s && setActive(i)}
+                className={cn(
+                  "group relative aspect-video overflow-hidden rounded-lg border border-border/60 bg-muted/40 transition",
+                  active === i && "border-electron ring-2 ring-electron/40",
+                  !s && "opacity-40",
+                )}
+              >
+                {s?.imageUrl ? (
+                  <img src={s.imageUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
+                ) : (
+                  <span className="absolute inset-0 flex items-center justify-center text-[10px] text-muted-foreground">
+                    {i + 1}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        <EventLog />
+      </div>
+    </aside>
+  );
+}
+
+function EventLog() {
+  const events = useStudioStore((s) => s.events);
+  return (
+    <div className="rounded-2xl border border-border/60 bg-ink-950/60 p-3">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        Event stream
+      </p>
+      <ul className="max-h-44 space-y-1.5 overflow-y-auto scrollbar-slim pr-1 font-mono text-[11px] text-muted-foreground">
+        {events.length === 0 && <li>· 대기 중…</li>}
+        {events.map((ev, i) => (
+          <motion.li
+            key={i}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="truncate"
+          >
+            <span className="text-electron">{ev.stage}</span>{" "}
+            <span className="text-foreground/70">{ev.message}</span>
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/components/studio/StepRail.tsx
+++ b/web/components/studio/StepRail.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Sparkles, FileText, Palette, Layers, Download } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useStudioStore } from "@/lib/store";
+import type { GenerateEvent } from "@/lib/api";
+
+const STEPS = [
+  { key: "prompt", label: "Prompt", icon: Sparkles, matchStages: [] as GenerateEvent["stage"][] },
+  { key: "research", label: "Research", icon: FileText, matchStages: ["research", "outline"] },
+  { key: "design", label: "Design", icon: Palette, matchStages: ["design"] },
+  { key: "render", label: "Render", icon: Layers, matchStages: ["render", "export"] },
+  { key: "export", label: "Export", icon: Download, matchStages: ["upload", "done"] },
+] as const;
+
+function currentStep(events: GenerateEvent[], hasJob: boolean): string {
+  if (!hasJob) return "prompt";
+  const latest = events.at(-1);
+  if (!latest) return "research";
+  for (let i = STEPS.length - 1; i >= 0; i--) {
+    if ((STEPS[i].matchStages as readonly string[]).includes(latest.stage)) return STEPS[i].key;
+  }
+  return "research";
+}
+
+export function StepRail() {
+  const events = useStudioStore((s) => s.events);
+  const hasJob = useStudioStore((s) => !!s.job);
+  const progress = useStudioStore((s) => s.progress);
+  const active = currentStep(events, hasJob);
+
+  return (
+    <aside className="flex h-full w-[220px] shrink-0 flex-col border-r border-border/60 bg-card/40 px-4 py-6 backdrop-blur-xl">
+      <p className="px-2 text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+        Pipeline
+      </p>
+
+      <ol className="mt-5 space-y-1">
+        {STEPS.map((step, idx) => {
+          const isActive = step.key === active;
+          const isDone =
+            STEPS.findIndex((s) => s.key === active) > idx && hasJob;
+          return (
+            <li key={step.key}>
+              <motion.div
+                layout
+                className={cn(
+                  "relative flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition",
+                  isActive && "bg-electron/10 text-foreground",
+                  !isActive && !isDone && "text-muted-foreground hover:bg-muted/40",
+                  isDone && "text-foreground",
+                )}
+              >
+                {isActive && (
+                  <motion.span
+                    layoutId="rail-indicator"
+                    className="absolute left-0 h-5 w-[3px] rounded-full bg-electron"
+                    transition={{ type: "spring", stiffness: 380, damping: 30 }}
+                  />
+                )}
+                <step.icon
+                  className={cn(
+                    "h-4 w-4",
+                    isActive && "text-electron",
+                    isDone && "text-aurora",
+                  )}
+                />
+                <span className="font-medium tracking-tight">{step.label}</span>
+                {isDone && (
+                  <span className="ml-auto text-[10px] uppercase tracking-widest text-aurora">
+                    done
+                  </span>
+                )}
+              </motion.div>
+            </li>
+          );
+        })}
+      </ol>
+
+      <div className="mt-auto rounded-2xl border border-border/60 bg-ink-900/50 p-4">
+        <p className="text-[10px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+          Progress
+        </p>
+        <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-border/70">
+          <motion.div
+            className="h-full rounded-full bg-[linear-gradient(90deg,hsl(var(--electron))_0%,hsl(var(--aurora))_100%)]"
+            animate={{ width: `${Math.round(progress * 100)}%` }}
+            transition={{ type: "spring", stiffness: 120, damping: 24 }}
+          />
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {hasJob ? `${Math.round(progress * 100)}%` : "Ready"}
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,0 +1,128 @@
+/**
+ * FastAPI client.
+ *
+ * We use a single-origin convention: `NEXT_PUBLIC_API_ORIGIN` in .env, or the
+ * Next rewrite under /proxy/* in dev. SSE is preferred for streaming since it
+ * works over standard fetch and survives proxies better than WebSocket.
+ */
+
+import type { ModelSlot } from "./models";
+
+const DEFAULT_API_ORIGIN =
+  process.env.NEXT_PUBLIC_API_ORIGIN || "/proxy";
+
+export type ModelOverrides = Partial<Record<ModelSlot, string>>;
+
+export interface GenerateRequest {
+  prompt: string;
+  attachments?: string[];
+  pages?: string | null;
+  models?: ModelOverrides;
+  output_name?: string;
+}
+
+export interface GenerateJob {
+  job_id: string;
+  status: "queued" | "running" | "succeeded" | "failed";
+  workspace: string;
+  created_at: number;
+}
+
+export interface GenerateEvent {
+  job_id: string;
+  stage:
+    | "research"
+    | "outline"
+    | "design"
+    | "render"
+    | "export"
+    | "upload"
+    | "done"
+    | "error"
+    | "log";
+  message: string;
+  percent?: number;
+  slide_index?: number;
+  slide_preview_url?: string;
+  pptx_url?: string;
+  error?: string;
+}
+
+export interface ModelCatalogResponse {
+  models: Array<{
+    id: string;
+    label: string;
+    kind: "chat" | "vision" | "image";
+    family: "google";
+    default_for: string[];
+    notes?: string | null;
+  }>;
+  defaults: Record<ModelSlot, string>;
+}
+
+function url(path: string): string {
+  const origin = DEFAULT_API_ORIGIN.replace(/\/$/, "");
+  return `${origin}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+export async function fetchModels(): Promise<ModelCatalogResponse> {
+  const res = await fetch(url("/models"), { cache: "no-store" });
+  if (!res.ok) throw new Error(`models fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchReadiness(): Promise<Record<string, unknown>> {
+  const res = await fetch(url("/readiness"), { cache: "no-store" });
+  if (!res.ok) throw new Error(`readiness fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function createJob(req: GenerateRequest): Promise<GenerateJob> {
+  const res = await fetch(url("/generate"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`createJob failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+/**
+ * Subscribe to SSE events for a running job. Returns an AbortController whose
+ * `abort()` method cleanly tears down the connection.
+ */
+export function streamEvents(
+  jobId: string,
+  onEvent: (ev: GenerateEvent) => void,
+  onError?: (err: unknown) => void,
+): AbortController {
+  const controller = new AbortController();
+  const evs = new EventSource(url(`/generate/${jobId}/events`));
+
+  evs.onmessage = (e) => {
+    try {
+      const payload: GenerateEvent = JSON.parse(e.data);
+      onEvent(payload);
+      if (payload.stage === "done" || payload.stage === "error") evs.close();
+    } catch (err) {
+      onError?.(err);
+    }
+  };
+  evs.onerror = (err) => {
+    onError?.(err);
+    evs.close();
+  };
+  controller.signal.addEventListener("abort", () => evs.close(), { once: true });
+  return controller;
+}
+
+export async function uploadAttachment(file: File): Promise<{ object_path: string; signed_url: string }> {
+  const body = new FormData();
+  body.append("file", file);
+  const res = await fetch(url("/generate/attachment"), { method: "POST", body });
+  if (!res.ok) throw new Error(`upload failed: ${res.status}`);
+  return res.json();
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -75,6 +75,28 @@ function url(path: string): string {
   return `${origin}${path.startsWith("/") ? path : `/${path}`}`;
 }
 
+/**
+ * Ping /health with a short timeout. Returns true iff the FastAPI server is
+ * reachable and responds with a 2xx. Used by the Studio to decide whether to
+ * submit the real job or fall back to the demo stream.
+ */
+export async function isApiReachable(timeoutMs = 2500): Promise<boolean> {
+  if (!process.env.NEXT_PUBLIC_API_ORIGIN && typeof window !== "undefined") {
+    // On a static export without a configured origin, there's nothing to ping.
+    return false;
+  }
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url("/health"), { signal: ctrl.signal, cache: "no-store" });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function fetchModels(): Promise<ModelCatalogResponse> {
   const res = await fetch(url("/models"), { cache: "no-store" });
   if (!res.ok) throw new Error(`models fetch failed: ${res.status}`);

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -8,8 +8,18 @@
 
 import type { ModelSlot } from "./models";
 
+/**
+ * Resolve the FastAPI origin.
+ *
+ * - In dev we can use the relative `/proxy` path because next.config.mjs
+ *   rewrites it to `http://localhost:7870`.
+ * - In `next export` builds (GitHub Pages), rewrites are ignored, so
+ *   NEXT_PUBLIC_API_ORIGIN must be a fully qualified URL baked in at
+ *   build time.
+ */
 const DEFAULT_API_ORIGIN =
-  process.env.NEXT_PUBLIC_API_ORIGIN || "/proxy";
+  process.env.NEXT_PUBLIC_API_ORIGIN ||
+  (process.env.NODE_ENV === "production" ? "" : "/proxy");
 
 export type ModelOverrides = Partial<Record<ModelSlot, string>>;
 

--- a/web/lib/demo.ts
+++ b/web/lib/demo.ts
@@ -1,0 +1,79 @@
+/**
+ * Demo mode: client-only event stream that mimics the real FastAPI pipeline.
+ *
+ * The Studio calls `runDemoJob` when `isApiReachable()` returns false. It
+ * fabricates a plausible sequence of stages so reviewers can evaluate the UI
+ * without any backend. All images are picked from a small curated list of
+ * Unsplash photos that already live in `next.config.mjs`'s remote allowlist.
+ */
+
+import type { GenerateEvent, GenerateJob } from "./api";
+
+const SAMPLE_COVERS = [
+  "https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1483817101829-339b08e8d83f?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1553877522-43269d4ea984?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1451187580459-43490279c0fa?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1529107386315-e1a2ed48a620?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1515879218367-8466d910aaa4?auto=format&fit=crop&w=1600&q=80",
+];
+
+const SLIDE_TITLES = [
+  "타이틀 · 비전 선언",
+  "시장 배경",
+  "문제 정의",
+  "솔루션 개요",
+  "경쟁 포지셔닝",
+  "실행 로드맵",
+];
+
+interface DemoOptions {
+  prompt: string;
+  onEvent: (ev: GenerateEvent) => void;
+}
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export function createDemoJob(prompt: string): GenerateJob {
+  return {
+    job_id: `demo-${Math.random().toString(36).slice(2, 10)}`,
+    status: "running",
+    workspace: "/demo",
+    created_at: Date.now() / 1000,
+  };
+}
+
+export async function runDemoJob({ prompt, onEvent }: DemoOptions): Promise<void> {
+  const jobId = `demo-${Math.random().toString(36).slice(2, 10)}`;
+  const emit = (ev: Omit<GenerateEvent, "job_id">) => onEvent({ job_id: jobId, ...ev });
+
+  emit({ stage: "log", message: `demo mode: echoing "${prompt.slice(0, 40)}..."` });
+  await delay(600);
+
+  emit({ stage: "research", message: "레퍼런스 수집 및 구조 초안 작성", percent: 0.12 });
+  await delay(900);
+
+  emit({ stage: "outline", message: "6-슬라이드 목차 확정", percent: 0.24 });
+  await delay(700);
+
+  for (let i = 0; i < SLIDE_TITLES.length; i++) {
+    emit({
+      stage: "design",
+      message: SLIDE_TITLES[i],
+      percent: 0.3 + (i / SLIDE_TITLES.length) * 0.5,
+      slide_index: i,
+      slide_preview_url: SAMPLE_COVERS[i % SAMPLE_COVERS.length],
+    });
+    await delay(700 + Math.random() * 500);
+  }
+
+  emit({ stage: "render", message: "HTML → PPTX 변환", percent: 0.9 });
+  await delay(700);
+
+  emit({
+    stage: "done",
+    message: "데모 완료 - 실제 PPTX 는 FastAPI 가 연결된 뒤 생성됩니다",
+    percent: 1,
+    pptx_url: "https://github.com/rkdghkclgns-design/PPTAgent#readme",
+  });
+}

--- a/web/lib/demo.ts
+++ b/web/lib/demo.ts
@@ -29,22 +29,26 @@ const SLIDE_TITLES = [
 
 interface DemoOptions {
   prompt: string;
+  jobId: string;
   onEvent: (ev: GenerateEvent) => void;
 }
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-export function createDemoJob(prompt: string): GenerateJob {
+function randomJobId(): string {
+  return `demo-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createDemoJob(_prompt: string): GenerateJob {
   return {
-    job_id: `demo-${Math.random().toString(36).slice(2, 10)}`,
+    job_id: randomJobId(),
     status: "running",
     workspace: "/demo",
     created_at: Date.now() / 1000,
   };
 }
 
-export async function runDemoJob({ prompt, onEvent }: DemoOptions): Promise<void> {
-  const jobId = `demo-${Math.random().toString(36).slice(2, 10)}`;
+export async function runDemoJob({ prompt, jobId, onEvent }: DemoOptions): Promise<void> {
   const emit = (ev: Omit<GenerateEvent, "job_id">) => onEvent({ job_id: jobId, ...ev });
 
   emit({ stage: "log", message: `demo mode: echoing "${prompt.slice(0, 40)}..."` });

--- a/web/lib/models.ts
+++ b/web/lib/models.ts
@@ -1,0 +1,105 @@
+/**
+ * Frontend-side model catalog.
+ *
+ * Mirrors `api/routes/models.py::GOOGLE_MODELS` so we can render the dropdown
+ * even before the API returns. The real defaults always come from the server.
+ */
+
+export type ModelKind = "chat" | "vision" | "image";
+
+export interface ModelOption {
+  id: string;
+  label: string;
+  kind: ModelKind;
+  family: "google";
+  notes?: string;
+  defaultFor?: ModelSlot[];
+}
+
+export type ModelSlot =
+  | "t2i_model"
+  | "research_agent"
+  | "long_context_model"
+  | "vision_model"
+  | "design_agent";
+
+export const MODEL_SLOT_LABEL: Record<ModelSlot, string> = {
+  t2i_model: "이미지 생성",
+  research_agent: "리서치 에이전트",
+  long_context_model: "긴 문맥",
+  vision_model: "비전 분석",
+  design_agent: "디자인 에이전트",
+};
+
+export const MODEL_SLOT_HINT: Record<ModelSlot, string> = {
+  t2i_model: "슬라이드 커버/일러스트 생성에 사용.",
+  research_agent: "프롬프트/첨부파일에서 개요를 뽑는 단계.",
+  long_context_model: "원문 전체를 한 번에 읽을 때 사용.",
+  vision_model: "참조 슬라이드 이미지 분석.",
+  design_agent: "HTML 슬라이드를 설계하는 최종 단계.",
+};
+
+/** Default model for each slot - Imagen is the global default per product decision. */
+export const DEFAULT_MODELS: Record<ModelSlot, string> = {
+  t2i_model: "google/imagen-3.0-generate-002",
+  research_agent: "google/gemini-2.0-flash",
+  long_context_model: "google/gemini-2.5-flash",
+  vision_model: "google/gemini-2.0-flash-vision",
+  design_agent: "google/gemini-2.5-pro",
+};
+
+export const GOOGLE_MODELS: ModelOption[] = [
+  {
+    id: "google/imagen-3.0-generate-002",
+    label: "Imagen 3.0 (Standard)",
+    kind: "image",
+    family: "google",
+    defaultFor: ["t2i_model"],
+    notes: "기본값. 16:9 커버와 인포그래픽에 최적.",
+  },
+  {
+    id: "google/imagen-3.0-fast-generate-001",
+    label: "Imagen 3.0 Fast",
+    kind: "image",
+    family: "google",
+    notes: "초안·프리뷰 전용 고속 모델.",
+  },
+  {
+    id: "google/gemini-2.0-flash",
+    label: "Gemini 2.0 Flash",
+    kind: "chat",
+    family: "google",
+    defaultFor: ["research_agent"],
+    notes: "빠르고 저렴. 리서치 기본값.",
+  },
+  {
+    id: "google/gemini-2.5-flash",
+    label: "Gemini 2.5 Flash",
+    kind: "chat",
+    family: "google",
+    defaultFor: ["long_context_model"],
+    notes: "200k+ 토큰의 긴 컨텍스트 처리.",
+  },
+  {
+    id: "google/gemini-2.5-pro",
+    label: "Gemini 2.5 Pro",
+    kind: "chat",
+    family: "google",
+    defaultFor: ["design_agent"],
+    notes: "최고 품질. 디자인 단계 기본값.",
+  },
+  {
+    id: "google/gemini-2.0-flash-vision",
+    label: "Gemini 2.0 Flash Vision",
+    kind: "vision",
+    family: "google",
+    defaultFor: ["vision_model"],
+    notes: "참조 슬라이드 이미지 이해.",
+  },
+];
+
+export function optionsForSlot(slot: ModelSlot): ModelOption[] {
+  const kind: ModelKind =
+    slot === "t2i_model" ? "image" : slot === "vision_model" ? "vision" : "chat";
+  return GOOGLE_MODELS.filter((m) => m.kind === kind);
+}

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -1,0 +1,93 @@
+/**
+ * Global Zustand store for the Studio page.
+ *
+ * Kept deliberately small - most state lives inside components and URL. The
+ * store owns (1) the current prompt/attachments/models draft, (2) the live
+ * event stream buffer, (3) the currently-selected slide in the preview.
+ */
+
+"use client";
+
+import { create } from "zustand";
+
+import { DEFAULT_MODELS, type ModelSlot } from "./models";
+import type { GenerateEvent, GenerateJob, ModelOverrides } from "./api";
+
+export interface SlidePreview {
+  index: number;
+  imageUrl?: string;
+  title?: string;
+}
+
+interface StudioState {
+  prompt: string;
+  attachments: { name: string; objectPath: string; size: number }[];
+  pages: string | null;
+  overrides: ModelOverrides;
+
+  job: GenerateJob | null;
+  events: GenerateEvent[];
+  slides: SlidePreview[];
+  activeSlide: number;
+  progress: number;
+  pptxUrl: string | null;
+
+  setPrompt: (value: string) => void;
+  setPages: (value: string | null) => void;
+  setModel: (slot: ModelSlot, id: string) => void;
+  addAttachment: (att: { name: string; objectPath: string; size: number }) => void;
+  removeAttachment: (objectPath: string) => void;
+  setJob: (job: GenerateJob | null) => void;
+  appendEvent: (ev: GenerateEvent) => void;
+  setActiveSlide: (index: number) => void;
+  reset: () => void;
+}
+
+const initialState = {
+  prompt: "",
+  attachments: [],
+  pages: null,
+  overrides: { ...DEFAULT_MODELS } as ModelOverrides,
+  job: null,
+  events: [],
+  slides: [],
+  activeSlide: 0,
+  progress: 0,
+  pptxUrl: null,
+};
+
+export const useStudioStore = create<StudioState>((set) => ({
+  ...initialState,
+  setPrompt: (value) => set({ prompt: value }),
+  setPages: (value) => set({ pages: value }),
+  setModel: (slot, id) =>
+    set((s) => ({ overrides: { ...s.overrides, [slot]: id } })),
+  addAttachment: (att) =>
+    set((s) => ({ attachments: [...s.attachments, att] })),
+  removeAttachment: (objectPath) =>
+    set((s) => ({
+      attachments: s.attachments.filter((a) => a.objectPath !== objectPath),
+    })),
+  setJob: (job) => set({ job, events: [], slides: [], progress: 0, pptxUrl: null }),
+  appendEvent: (ev) =>
+    set((s) => {
+      const events = [...s.events, ev];
+      let { slides, activeSlide, progress, pptxUrl } = s;
+      if (typeof ev.percent === "number") progress = Math.max(progress, ev.percent);
+      if (ev.stage === "design" && typeof ev.slide_index === "number") {
+        const idx = ev.slide_index;
+        const next = [...slides];
+        next[idx] = {
+          index: idx,
+          imageUrl: ev.slide_preview_url ?? next[idx]?.imageUrl,
+          title: ev.message,
+        };
+        slides = next;
+        activeSlide = idx;
+      }
+      if (ev.pptx_url) pptxUrl = ev.pptx_url;
+      return { events, slides, activeSlide, progress, pptxUrl };
+    }),
+  setActiveSlide: (index) => set({ activeSlide: index }),
+  reset: () => set({ ...initialState }),
+}));

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -71,22 +71,28 @@ export const useStudioStore = create<StudioState>((set) => ({
   setJob: (job) => set({ job, events: [], slides: [], progress: 0, pptxUrl: null }),
   appendEvent: (ev) =>
     set((s) => {
-      const events = [...s.events, ev];
-      let { slides, activeSlide, progress, pptxUrl } = s;
-      if (typeof ev.percent === "number") progress = Math.max(progress, ev.percent);
-      if (ev.stage === "design" && typeof ev.slide_index === "number") {
-        const idx = ev.slide_index;
-        const next = [...slides];
-        next[idx] = {
-          index: idx,
-          imageUrl: ev.slide_preview_url ?? next[idx]?.imageUrl,
-          title: ev.message,
-        };
-        slides = next;
-        activeSlide = idx;
-      }
-      if (ev.pptx_url) pptxUrl = ev.pptx_url;
-      return { events, slides, activeSlide, progress, pptxUrl };
+      const progress =
+        typeof ev.percent === "number" ? Math.max(s.progress, ev.percent) : s.progress;
+      const [slides, activeSlide] =
+        ev.stage === "design" && typeof ev.slide_index === "number"
+          ? (() => {
+              const idx = ev.slide_index;
+              const next = s.slides.slice();
+              next[idx] = {
+                index: idx,
+                imageUrl: ev.slide_preview_url ?? next[idx]?.imageUrl,
+                title: ev.message,
+              };
+              return [next, idx] as const;
+            })()
+          : ([s.slides, s.activeSlide] as const);
+      return {
+        events: [...s.events, ev],
+        slides,
+        activeSlide,
+        progress,
+        pptxUrl: ev.pptx_url ?? s.pptxUrl,
+      };
     }),
   setActiveSlide: (index) => set({ activeSlide: index }),
   reset: () => set({ ...initialState }),

--- a/web/lib/supabase.ts
+++ b/web/lib/supabase.ts
@@ -1,0 +1,24 @@
+/**
+ * Browser Supabase client - used only for auth-session reads and public
+ * buckets. All sensitive operations (Google API proxy, storage writes) go
+ * through the FastAPI server.
+ */
+
+"use client";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let cached: SupabaseClient | null = null;
+
+export function getSupabaseBrowser(): SupabaseClient {
+  if (cached) return cached;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) {
+    throw new Error(
+      "Supabase env vars not set. Add NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY to web/.env.local",
+    );
+  }
+  cached = createClient(url, key, { auth: { persistSession: true } });
+  return cached;
+}

--- a/web/lib/utils.ts
+++ b/web/lib/utils.ts
@@ -1,0 +1,20 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge Tailwind classes without duplicates. */
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}
+
+/** Format a file size in bytes into a human-friendly string. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const exp = Math.min(Math.floor(Math.log10(bytes) / 3), units.length - 1);
+  return `${(bytes / Math.pow(1000, exp)).toFixed(exp === 0 ? 0 : 1)} ${units[exp]}`;
+}
+
+/** Clamp a number between min and max. */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,19 +1,52 @@
+/**
+ * Next.js config — tuned for dual-target builds:
+ *
+ *   1. Local dev / Vercel       → standard SSR build (`next dev`, `next build`)
+ *   2. GitHub Pages             → static export with a /PPTAgent basePath
+ *
+ * Switch is driven by `DEPLOY_TARGET=pages` (set by the Pages workflow).
+ *
+ * Caveats for the Pages target:
+ *   - `rewrites()` is silently ignored by `next export`, so the client must
+ *     hit the FastAPI origin directly. Set NEXT_PUBLIC_API_ORIGIN to the full
+ *     URL of the deployed API (e.g. https://pptagent-api.fly.dev).
+ *   - Image optimisation is disabled because GitHub Pages has no optimizer.
+ */
+
+const isPages = process.env.DEPLOY_TARGET === "pages";
+const repoName = "PPTAgent";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true,
   },
-  images: {
-    remotePatterns: [
-      { protocol: "https", hostname: "**.supabase.co" },
-      { protocol: "https", hostname: "images.unsplash.com" },
-    ],
-  },
-  async rewrites() {
-    const apiOrigin = process.env.NEXT_PUBLIC_API_ORIGIN ?? "http://localhost:7870";
-    return [{ source: "/proxy/:path*", destination: `${apiOrigin}/:path*` }];
-  },
+  // Static export for GitHub Pages
+  ...(isPages
+    ? {
+        output: "export",
+        basePath: `/${repoName}`,
+        assetPrefix: `/${repoName}/`,
+        trailingSlash: true,
+      }
+    : {}),
+  images: isPages
+    ? { unoptimized: true }
+    : {
+        remotePatterns: [
+          { protocol: "https", hostname: "**.supabase.co" },
+          { protocol: "https", hostname: "images.unsplash.com" },
+        ],
+      },
+  ...(isPages
+    ? {}
+    : {
+        async rewrites() {
+          const apiOrigin = process.env.NEXT_PUBLIC_API_ORIGIN ?? "http://localhost:7870";
+          return [{ source: "/proxy/:path*", destination: `${apiOrigin}/:path*` }];
+        },
+      }),
 };
 
 export default nextConfig;

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,0 +1,19 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+  },
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "**.supabase.co" },
+      { protocol: "https", hostname: "images.unsplash.com" },
+    ],
+  },
+  async rewrites() {
+    const apiOrigin = process.env.NEXT_PUBLIC_API_ORIGIN ?? "http://localhost:7870";
+    return [{ source: "/proxy/:path*", destination: `${apiOrigin}/:path*` }];
+  },
+};
+
+export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "pptagent-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Dribbble-style Next.js frontend for PPTAgent",
+  "scripts": {
+    "dev": "next dev --turbo -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-dropdown-menu": "^2.1.2",
+    "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-progress": "^1.1.0",
+    "@radix-ui/react-scroll-area": "^1.2.0",
+    "@radix-ui/react-select": "^2.1.2",
+    "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-switch": "^1.1.1",
+    "@radix-ui/react-tabs": "^1.1.1",
+    "@radix-ui/react-tooltip": "^1.1.4",
+    "@supabase/supabase-js": "^2.47.7",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.15.0",
+    "lucide-react": "^0.468.0",
+    "next": "14.2.21",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-dropzone": "^14.3.5",
+    "sonner": "^1.7.1",
+    "tailwind-merge": "^2.5.5",
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^18.3.17",
+    "@types/react-dom": "^18.3.5",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.21",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2"
+  }
+}

--- a/web/postcss.config.mjs
+++ b/web/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,118 @@
+import type { Config } from "tailwindcss";
+
+/**
+ * Dribbble-style design tokens.
+ *
+ * Palette: Deep Space charcoal, Electron Purple (signature), warm off-white
+ * Aurora accent, and sparing use of a Sunrise highlight. All values are
+ * exposed as CSS variables in globals.css so dark/light modes can swap them.
+ */
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "1.25rem",
+      screens: { "2xl": "1440px" },
+    },
+    extend: {
+      colors: {
+        // Brand
+        ink: {
+          50: "hsl(var(--ink-50))",
+          100: "hsl(var(--ink-100))",
+          200: "hsl(var(--ink-200))",
+          300: "hsl(var(--ink-300))",
+          400: "hsl(var(--ink-400))",
+          500: "hsl(var(--ink-500))",
+          600: "hsl(var(--ink-600))",
+          700: "hsl(var(--ink-700))",
+          800: "hsl(var(--ink-800))",
+          900: "hsl(var(--ink-900))",
+          950: "hsl(var(--ink-950))",
+        },
+        electron: {
+          DEFAULT: "hsl(var(--electron))",
+          soft: "hsl(var(--electron-soft))",
+          glow: "hsl(var(--electron-glow))",
+        },
+        aurora: "hsl(var(--aurora))",
+        sunrise: "hsl(var(--sunrise))",
+
+        // Semantic
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: "hsl(var(--card))",
+        "card-foreground": "hsl(var(--card-foreground))",
+        muted: "hsl(var(--muted))",
+        "muted-foreground": "hsl(var(--muted-foreground))",
+        border: "hsl(var(--border))",
+        ring: "hsl(var(--ring))",
+        destructive: "hsl(var(--destructive))",
+      },
+      fontFamily: {
+        sans: ["var(--font-satoshi)", "var(--font-inter)", "system-ui", "sans-serif"],
+        display: ["var(--font-satoshi)", "var(--font-inter)", "system-ui", "sans-serif"],
+        mono: ["var(--font-jetbrains)", "ui-monospace", "SFMono-Regular", "monospace"],
+      },
+      fontSize: {
+        "display-xl": ["5.75rem", { lineHeight: "1", letterSpacing: "-0.04em", fontWeight: "700" }],
+        "display-lg": ["4rem", { lineHeight: "1.02", letterSpacing: "-0.035em", fontWeight: "700" }],
+        "display-md": ["3rem", { lineHeight: "1.05", letterSpacing: "-0.03em", fontWeight: "700" }],
+        "display-sm": ["2.25rem", { lineHeight: "1.1", letterSpacing: "-0.025em", fontWeight: "600" }],
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 4px)",
+        sm: "calc(var(--radius) - 8px)",
+        "2xl": "1.25rem",
+        "3xl": "1.75rem",
+      },
+      boxShadow: {
+        glass:
+          "inset 0 1px 0 hsl(0 0% 100% / 0.06), 0 1px 2px hsl(0 0% 0% / 0.3), 0 20px 40px -20px hsl(var(--electron) / 0.25)",
+        halo: "0 0 0 1px hsl(var(--electron) / 0.35), 0 0 60px hsl(var(--electron-glow) / 0.45)",
+        soft: "0 1px 0 hsl(0 0% 100% / 0.04), 0 30px 60px -30px hsl(0 0% 0% / 0.6)",
+      },
+      backgroundImage: {
+        "mesh-aurora":
+          "radial-gradient(60% 60% at 20% 0%, hsl(var(--electron-glow) / 0.22) 0%, transparent 60%)," +
+          "radial-gradient(50% 50% at 100% 20%, hsl(var(--aurora) / 0.18) 0%, transparent 60%)," +
+          "radial-gradient(40% 40% at 50% 100%, hsl(var(--sunrise) / 0.12) 0%, transparent 60%)",
+        "grid-faint":
+          "linear-gradient(hsl(var(--border)) 1px, transparent 1px)," +
+          "linear-gradient(90deg, hsl(var(--border)) 1px, transparent 1px)",
+      },
+      backgroundSize: {
+        "grid-24": "24px 24px",
+      },
+      keyframes: {
+        shimmer: {
+          "0%, 100%": { backgroundPosition: "0% 50%" },
+          "50%": { backgroundPosition: "100% 50%" },
+        },
+        breathing: {
+          "0%, 100%": { opacity: "0.8", transform: "scale(1)" },
+          "50%": { opacity: "1", transform: "scale(1.015)" },
+        },
+        "fade-up": {
+          from: { opacity: "0", transform: "translateY(12px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      animation: {
+        shimmer: "shimmer 6s ease-in-out infinite",
+        breathing: "breathing 4s ease-in-out infinite",
+        "fade-up": "fade-up 600ms cubic-bezier(0.22, 1, 0.36, 1) both",
+      },
+    },
+  },
+  plugins: [require("tailwindcss-animate")],
+};
+
+export default config;

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Replace in-memory `AgentBridge._jobs` with Postgres-backed persistence so cold-stopped Fly machines don't lose jobs between submit and SSE reconnect.
- New `supabase/migrations/20260417_jobs.sql` creates `jobs` + `job_events` with RLS keyed on `owner_sub = auth.jwt().sub`, and publishes `job_events` to `supabase_realtime`.
- New `api/core/jobs_repo.py` is a thin PostgREST client with `enabled=False` fallback for local dev.
- `AgentBridge.restore(job_id)` hydrates a `Job` from the DB; `GET /generate/{id}/events` now falls back to it before 404.

## Test plan
- [ ] `supabase db push` applies the migration against the linked project
- [ ] Submit a job → verify `jobs` row created, `job_events` row per stage
- [ ] Kill FastAPI mid-run, restart it, reconnect SSE on the same `job_id` → events replay from the DB
- [ ] Authenticated user A cannot SELECT user B's jobs (RLS check)
- [ ] Without `SUPABASE_URL` env, repo logs a no-op and the bridge still works in-memory only

## Notes
- DB writes are best-effort: a failed INSERT is logged but does not kill the pipeline.
- Realtime publication is opt-in. Current frontend still reads from SSE; direct subscription is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)