### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/deeppresenter/config.yaml.example
+++ b/deeppresenter/config.yaml.example
@@ -17,6 +17,13 @@ long_context_model:
   model: "glm-4.5"
   api_key: "your_key"
 
+# # LiteLLM provider example — pip install pptagent[litellm]
+# # Routes to 100+ providers (Anthropic, Gemini, Bedrock, etc.) without a proxy.
+# research_agent:
+#   provider: "litellm"
+#   model: "anthropic/claude-sonnet-4-6"
+#   api_key: "your_anthropic_key"
+
 # # this is not neccessarily required,
 
 # vision_model:

--- a/deeppresenter/utils/config.py
+++ b/deeppresenter/utils/config.py
@@ -73,23 +73,53 @@ def get_json_from_response(response: str) -> dict | list:
 class Endpoint(BaseModel):
     """LLM Endpoint Configuration"""
 
-    base_url: str = Field(description="API base URL")
+    base_url: str | None = Field(default=None, description="API base URL")
     model: str = Field(description="Model name")
-    api_key: str = Field(description="API key")
+    api_key: str | None = Field(default=None, description="API key")
+    provider: str = Field(
+        default="openai",
+        description="Backend provider: 'openai' (default) or 'litellm'",
+    )
     client_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Client parameters"
     )
     sampling_parameters: dict[str, Any] = Field(
         default_factory=dict, description="Sampling parameters"
     )
-    _client: AsyncOpenAI = PrivateAttr()
+    _client: AsyncOpenAI | None = PrivateAttr(default=None)
 
     def model_post_init(self, _) -> None:
-        self._client = AsyncOpenAI(
-            api_key=self.api_key,
-            base_url=self.base_url,
-            **self.client_kwargs,
-        )
+        if self.provider != "litellm":
+            self._client = AsyncOpenAI(
+                api_key=self.api_key,
+                base_url=self.base_url,
+                **self.client_kwargs,
+            )
+
+    async def _call_litellm(
+        self,
+        messages: list[dict[str, Any]],
+        response_format: type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> ChatCompletion:
+        import litellm
+
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "drop_params": True,
+            **self.sampling_parameters,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["api_base"] = self.base_url
+        if tools is not None:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        return await litellm.acompletion(**kwargs)
 
     async def call(
         self,
@@ -99,7 +129,9 @@ class Endpoint(BaseModel):
         tools: list[dict[str, Any]] | None = None,
     ) -> ChatCompletion:
         """Execute a chat or tool call using the endpoint client"""
-        if tools is not None:
+        if self.provider == "litellm":
+            response = await self._call_litellm(messages, response_format, tools)
+        elif tools is not None:
             response = await self._client.chat.completions.create(
                 model=self.model,
                 messages=messages,
@@ -144,6 +176,10 @@ class LLM(BaseModel):
     base_url: str | None = Field(default=None, description="API base URL")
     model: str | None = Field(default=None, description="Model name")
     api_key: str | None = Field(default=None, description="API key")
+    provider: str = Field(
+        default="openai",
+        description="Backend provider: 'openai' (default) or 'litellm'",
+    )
     identifier: str | None = Field(
         default=None,
         description="Optional identifier for the model instance, this will override property `model_name`",
@@ -195,6 +231,7 @@ class LLM(BaseModel):
                     base_url=self.base_url,
                     model=self.model,
                     api_key=self.api_key,
+                    provider=self.provider,
                     client_kwargs=self.client_kwargs,
                     sampling_parameters=self.sampling_parameters,
                 ),
@@ -274,13 +311,35 @@ class LLM(BaseModel):
                 # t2i is stateless
                 endpoint = self._endpoints[retry_idx % len(self._endpoints)]
                 try:
-                    response = await endpoint._client.images.generate(
-                        prompt=prompt,
-                        model=endpoint.model,
-                        size=f"{width}x{height}",
-                        timeout=MCP_CALL_TIMEOUT // 5,
-                        **endpoint.sampling_parameters,
-                    )
+                    if endpoint.provider == "litellm":
+                        import litellm
+
+                        response = await litellm.aimage_generation(
+                            prompt=prompt,
+                            model=endpoint.model,
+                            size=f"{width}x{height}",
+                            timeout=MCP_CALL_TIMEOUT // 5,
+                            drop_params=True,
+                            **(
+                                {"api_key": endpoint.api_key}
+                                if endpoint.api_key
+                                else {}
+                            ),
+                            **(
+                                {"api_base": endpoint.base_url}
+                                if endpoint.base_url
+                                else {}
+                            ),
+                            **endpoint.sampling_parameters,
+                        )
+                    else:
+                        response = await endpoint._client.images.generate(
+                            prompt=prompt,
+                            model=endpoint.model,
+                            size=f"{width}x{height}",
+                            timeout=MCP_CALL_TIMEOUT // 5,
+                            **endpoint.sampling_parameters,
+                        )
                     assert len(response.data) >= 1, (
                         f"Expected at least an image response, got {response}"
                     )
@@ -299,8 +358,24 @@ class LLM(BaseModel):
 
     async def validate(self):
         endpoint = self._endpoints[0]
+        if endpoint.provider == "litellm":
+            import litellm
+
+            try:
+                await litellm.acompletion(
+                    model=endpoint.model,
+                    messages=[{"role": "user", "content": "ping"}],
+                    max_tokens=1,
+                    drop_params=True,
+                    **({"api_key": endpoint.api_key} if endpoint.api_key else {}),
+                    **({"api_base": endpoint.base_url} if endpoint.base_url else {}),
+                )
+            except Exception as e:
+                raise Exception(
+                    f"LiteLLM validation failed for model {endpoint.model}: {e}\n"
+                ) from e
+            return
         models = await endpoint._client.models.list()
-        # ? This for compatibility with google generative ai
         if not any(model.id.endswith(endpoint.model) for model in models.data):
             raise Exception(
                 f"Model {endpoint.model} is not available at {endpoint.base_url}, please check your apikey or {PACKAGE_DIR / 'config.yaml'}\n"

--- a/deeppresenter/utils/config.py
+++ b/deeppresenter/utils/config.py
@@ -3,7 +3,7 @@ import json
 import random
 from itertools import cycle, product
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import json_repair
 import yaml
@@ -76,7 +76,7 @@ class Endpoint(BaseModel):
     base_url: str | None = Field(default=None, description="API base URL")
     model: str = Field(description="Model name")
     api_key: str | None = Field(default=None, description="API key")
-    provider: str = Field(
+    provider: Literal['openai', 'litellm'] = Field(
         default="openai",
         description="Backend provider: 'openai' (default) or 'litellm'",
     )
@@ -301,7 +301,7 @@ class LLM(BaseModel):
             ratio = (int(self.min_image_size) / (width * height)) ** 0.5
             width = int(width * ratio)
             height = int(height * ratio)
-        assert (width % PIXEL_MULTIPLE == 0) and (height % PIXEL_MULTIPLE == 0), (
+        assert (width % pixel_multiple == 0) and (height % PIXEL_MULTIPLE == 0), (
             f"Image width and height must be a multiple of {pixel_multiple}"
         )
         async with self._semaphore:

--- a/pptagent/litellm.py
+++ b/pptagent/litellm.py
@@ -1,0 +1,177 @@
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from pptagent.llms import LLM, AsyncLLM
+from pptagent.utils import get_logger, tenacity_decorator
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class LiteLLMLLM(LLM):
+    """LLM wrapper that uses LiteLLM for multi-provider support."""
+
+    def __post_init__(self) -> None:
+        self.client = None
+
+    @tenacity_decorator
+    def __call__(
+        self,
+        content: str,
+        images: str | list[str] | None = None,
+        system_message: str | None = None,
+        history: list | None = None,
+        return_json: bool = False,
+        return_message: bool = False,
+        response_format: BaseModel | None = None,
+        **client_kwargs,
+    ) -> str | dict | list | tuple:
+        import litellm
+
+        if history is None:
+            history = []
+        system, message = self.format_message(content, images, system_message)
+        kwargs: dict = {
+            "model": self.model,
+            "messages": system + history + message,
+            "drop_params": True,
+            **client_kwargs,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["api_base"] = self.base_url
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        try:
+            completion = litellm.completion(**kwargs)
+        except Exception as e:
+            logger.warning("Error in LiteLLM (%s) service: %s", self.model, e)
+            raise
+        response = completion.choices[0].message.content
+        message.append({"role": "assistant", "content": response})
+        return self.__post_process__(response, message, return_json, return_message)
+
+    def test_connection(self) -> bool:
+        import litellm
+
+        try:
+            litellm.completion(
+                model=self.model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+                drop_params=True,
+                **({"api_key": self.api_key} if self.api_key else {}),
+                **({"api_base": self.base_url} if self.base_url else {}),
+            )
+            return True
+        except Exception as e:
+            logger.warning("LiteLLM connection test failed: %s", e)
+            return False
+
+    def gen_image(self, prompt: str, n: int = 1, **kwargs) -> str:
+        import litellm
+
+        response = litellm.image_generation(
+            model=self.model,
+            prompt=prompt,
+            n=n,
+            drop_params=True,
+            **({"api_key": self.api_key} if self.api_key else {}),
+            **({"api_base": self.base_url} if self.base_url else {}),
+            **kwargs,
+        )
+        return response.data[0].b64_json
+
+    def to_async(self) -> "AsyncLiteLLMLLM":
+        return AsyncLiteLLMLLM(
+            model=self.model,
+            base_url=self.base_url,
+            api_key=self.api_key,
+            timeout=self.timeout,
+        )
+
+
+@dataclass
+class AsyncLiteLLMLLM(AsyncLLM):
+    """Async LLM wrapper that uses LiteLLM for multi-provider support."""
+
+    def __post_init__(self) -> None:
+        self.client = None
+        self.batch = None
+
+    @tenacity_decorator
+    async def __call__(
+        self,
+        content: str,
+        images: str | list[str] | None = None,
+        system_message: str | None = None,
+        history: list | None = None,
+        return_json: bool = False,
+        return_message: bool = False,
+        response_format: BaseModel | None = None,
+        **client_kwargs,
+    ) -> str | dict | tuple:
+        import litellm
+
+        if history is None:
+            history = []
+        system, message = self.format_message(content, images, system_message)
+        kwargs: dict = {
+            "model": self.model,
+            "messages": system + history + message,
+            "drop_params": True,
+            **client_kwargs,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["api_base"] = self.base_url
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        try:
+            completion = await litellm.acompletion(**kwargs)
+        except Exception as e:
+            logger.error("Error in AsyncLiteLLMLLM call: %s", e)
+            raise
+        response = completion.choices[0].message.content
+        message.append({"role": "assistant", "content": response})
+        return self.__post_process__(response, message, return_json, return_message)
+
+    async def test_connection(self) -> bool:
+        import litellm
+
+        try:
+            await litellm.acompletion(
+                model=self.model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+                drop_params=True,
+                **({"api_key": self.api_key} if self.api_key else {}),
+                **({"api_base": self.base_url} if self.base_url else {}),
+            )
+            return True
+        except Exception as e:
+            logger.warning("LiteLLM async connection test failed: %s", e)
+            return False
+
+    async def gen_image(self, prompt: str, n: int = 1, **kwargs) -> str:
+        import litellm
+
+        response = await litellm.aimage_generation(
+            model=self.model,
+            prompt=prompt,
+            n=n,
+            response_format="b64_json",
+            drop_params=True,
+            **({"api_key": self.api_key} if self.api_key else {}),
+            **({"api_base": self.base_url} if self.base_url else {}),
+            **kwargs,
+        )
+        return response.data[0].b64_json
+
+    def to_sync(self) -> LiteLLMLLM:
+        return LiteLLMLLM(
+            model=self.model, base_url=self.base_url, api_key=self.api_key
+        )

--- a/pptagent/test/test_litellm.py
+++ b/pptagent/test/test_litellm.py
@@ -1,0 +1,108 @@
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+def _install_litellm_stub():
+    """Install a fake litellm module so tests run without the real package."""
+    fake = types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(name="litellm.completion")
+    fake.acompletion = mock.AsyncMock(name="litellm.acompletion")
+    fake.image_generation = mock.MagicMock(name="litellm.image_generation")
+    fake.aimage_generation = mock.AsyncMock(name="litellm.aimage_generation")
+    sys.modules["litellm"] = fake
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def litellm_stub():
+    fake = _install_litellm_stub()
+    yield fake
+    sys.modules.pop("litellm", None)
+
+
+def _make_completion_response(content: str = "Hello!"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def test_litellm_llm_calls_completion(litellm_stub):
+    litellm_stub.completion.return_value = _make_completion_response("test reply")
+
+    from pptagent.litellm import LiteLLMLLM
+
+    llm = LiteLLMLLM(model="anthropic/claude-haiku-4-5", api_key="sk-test")
+    result = llm("Hello")
+
+    litellm_stub.completion.assert_called_once()
+    call_kwargs = litellm_stub.completion.call_args
+    assert call_kwargs.kwargs["model"] == "anthropic/claude-haiku-4-5"
+    assert call_kwargs.kwargs["api_key"] == "sk-test"
+    assert call_kwargs.kwargs["drop_params"] is True
+    assert result == "test reply"
+
+
+def test_litellm_llm_omits_blank_credentials(litellm_stub):
+    litellm_stub.completion.return_value = _make_completion_response()
+
+    from pptagent.litellm import LiteLLMLLM
+
+    llm = LiteLLMLLM(model="openai/gpt-4o")
+    llm("Hi")
+
+    call_kwargs = litellm_stub.completion.call_args.kwargs
+    assert "api_key" not in call_kwargs
+    assert "api_base" not in call_kwargs
+
+
+def test_litellm_llm_forwards_base_url(litellm_stub):
+    litellm_stub.completion.return_value = _make_completion_response()
+
+    from pptagent.litellm import LiteLLMLLM
+
+    llm = LiteLLMLLM(
+        model="custom/model", base_url="http://localhost:8000", api_key="key"
+    )
+    llm("Hi")
+
+    call_kwargs = litellm_stub.completion.call_args.kwargs
+    assert call_kwargs["api_base"] == "http://localhost:8000"
+
+
+@pytest.mark.asyncio
+async def test_async_litellm_llm_calls_acompletion(litellm_stub):
+    litellm_stub.acompletion.return_value = _make_completion_response("async reply")
+
+    from pptagent.litellm import AsyncLiteLLMLLM
+
+    llm = AsyncLiteLLMLLM(model="anthropic/claude-haiku-4-5", api_key="sk-test")
+    result = await llm("Hello")
+
+    litellm_stub.acompletion.assert_called_once()
+    call_kwargs = litellm_stub.acompletion.call_args.kwargs
+    assert call_kwargs["drop_params"] is True
+    assert result == "async reply"
+
+
+def test_litellm_llm_to_async(litellm_stub):
+    from pptagent.litellm import AsyncLiteLLMLLM, LiteLLMLLM
+
+    llm = LiteLLMLLM(model="anthropic/claude-haiku-4-5", api_key="sk-test")
+    async_llm = llm.to_async()
+    assert isinstance(async_llm, AsyncLiteLLMLLM)
+    assert async_llm.model == "anthropic/claude-haiku-4-5"
+    assert async_llm.api_key == "sk-test"
+
+
+def test_async_litellm_llm_to_sync(litellm_stub):
+    from pptagent.litellm import AsyncLiteLLMLLM, LiteLLMLLM
+
+    llm = AsyncLiteLLMLLM(model="gemini/gemini-2.0-flash", api_key="key")
+    sync_llm = llm.to_sync()
+    assert isinstance(sync_llm, LiteLLMLLM)
+    assert sync_llm.model == "gemini/gemini-2.0-flash"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+litellm = [
+    "litellm>=1.65,<1.85",
+]
 full = [
     "transformers<4.50.0",
     "fasttext",


### PR DESCRIPTION
  ## Summary
  - Adds LiteLLM as an optional AI gateway provider for both `deeppresenter` and `pptagent` stacks
  - Enables direct access to 100+ LLM providers (Anthropic, Gemini, Bedrock, Vertex AI, Groq, etc.) without needing an OpenRouter/proxy intermediary                                                                 
                                                                                                                                                                                                                     
  ## Motivation                                                                                                                                                                                                      
  PPTAgent currently routes all LLM calls through the OpenAI SDK, requiring users to either use OpenAI directly or configure an OpenAI-compatible proxy (OpenRouter, BigModel, etc.). Adding LiteLLM as a native     
  provider option lets users connect to any supported provider with just `provider: "litellm"` and the provider-prefixed model name (e.g. `anthropic/claude-sonnet-4-6`), with automatic parameter translation across
   providers.
                                                                                                                                                                                                                     
                                                                                                                                                                                                                     
  ## Changes
  - `deeppresenter/utils/config.py` - Added `provider` field to `Endpoint` and `LLM` classes. When `provider: "litellm"`, calls route through `litellm.acompletion()` instead of AsyncOpenAI. Includes               
  `drop_params=True` by default for cross-provider compatibility.                                                                                                                                                    
  - `pptagent/litellm.py` - New `LiteLLMLLM` and `AsyncLiteLLMLLM` classes extending the existing `LLM`/`AsyncLLM` with LiteLLM-backed completion, connection testing, and image generation.
  - `pyproject.toml` - Added `litellm>=1.65,<1.85` as optional dependency under `[project.optional-dependencies].litellm`                                                                                            
  - `deeppresenter/config.yaml.example` - Added commented LiteLLM configuration example
  - `pptagent/test/test_litellm.py` - 6 unit tests covering sync/async completion dispatch, credential forwarding, `drop_params` default, and sync/async conversion                                                  
                                                                                                                                                                                                                     
  ## Tests                                                                                                                                                                      
                                                                                                                                                                                                                     
  **1. Unit tests:** `OPENAI_API_KEY=sk-dummy pytest pptagent/test/test_litellm.py -v`                                                                                                                               
  ```           
  pptagent/test/test_litellm.py::test_litellm_llm_calls_completion PASSED  [ 16%]                                                                                                                                    
  pptagent/test/test_litellm.py::test_litellm_llm_omits_blank_credentials PASSED [ 33%]                                                                                                                              
  pptagent/test/test_litellm.py::test_litellm_llm_forwards_base_url PASSED [ 50%]                                                                                                                                    
  pptagent/test/test_litellm.py::test_async_litellm_llm_calls_acompletion PASSED [ 66%]                                                                                                                              
  pptagent/test/test_litellm.py::test_litellm_llm_to_async PASSED          [ 83%]                                                                                                                                    
  pptagent/test/test_litellm.py::test_async_litellm_llm_to_sync PASSED     [100%]                                                                                                                                    
                                                                                                                                                                                                                     
  ============================== 6 passed in 0.02s ===============================                                                                                                                                   
  ```                                                                                                                                                                                                                
                                                                                                                                                                                                                     
  **2. Format checks:** `ruff check` + `ruff format --check` - all clean                                                                                                                                             
                                                                                                                                                                                                                     
  **3. Pin resolution verified:** `pip install -e '.[litellm]'` resolves cleanly with `litellm>=1.65,<1.85`                                                                                                          
                                                                                                                                                                                                                   
  ## Usage                                                                                                                                                                                                           
                                                                                                                                                                                                                   
  **Install:**                                                                                                                                                                                                       
  ```bash                         
  pip install pptagent[litellm]                                                                                                                                                                                      
  ```             

  **deeppresenter (config.yaml):**
  ```yaml
  research_agent:
    provider: "litellm"
    model: "anthropic/claude-sonnet-4-6"                                                                                                                                                                           
    api_key: "your_anthropic_key"                                                                                                                                                                                    
                                  
  design_agent:                                                                                                                                                                                                      
    provider: "litellm"                                                                                                                                                                                              
    model: "gemini/gemini-2.5-flash"
    api_key: "your_google_key"                                                                                                                                                                                       
  ```             
                                                                                                                                                                                                                   
  **pptagent (Python):**                                                                                                                                                                                             
  ```python                       
  from pptagent.litellm import AsyncLiteLLMLLM                                                                                                                                                                       
                  
  llm = AsyncLiteLLMLLM(model="anthropic/claude-sonnet-4-6", api_key="sk-ant-...")                                                                                                                                 
  response = await llm("Generate a slide about AI trends")                                                                                                                                                           
  print(response)                 
  ```                                                                                                                                                                                                                
                                                                                                                                                                                                                     
  **Environment variables (no api_key needed):**
  ```bash                                                                                                                                                                                                            
  export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                                
  ```                             
  ```python                                                                                                                                                                                                          
  from pptagent.litellm import LiteLLMLLM

  llm = LiteLLMLLM(model="anthropic/claude-sonnet-4-6")
  response = llm("Summarize this document for a presentation")                                                                                                                                                     
  print(response)                                                                                                                                                                                                    
  ```                                                                                                                                                                                                              
                                                                                                                                                                                                                     
  **Supported model name examples:**
  ```                                                                                                                                                                                                                
  openai/gpt-4o   
  anthropic/claude-sonnet-4-6
  gemini/gemini-2.5-flash
  deepseek/deepseek-chat
  groq/llama-3.3-70b-versatile                                                                                                                                                                                     
  bedrock/anthropic.claude-v2                                                                                                                                                                                        
  vertex_ai/gemini-2.5-pro        
  mistral/mistral-large-latest                                                                                                                                                                                       
  ```                                                                                                                                                                                                              
                                                                                                                                                                                                                     
  ## Risk / Compatibility         
  - Additive only. Existing OpenAI-backed providers untouched (default `provider: "openai"`).                                                                                                                        
  - `litellm` is an optional dependency. Base install unaffected.
  - LiteLLM lazy-imported inside function bodies to avoid import errors when not installed.                                                                                                                        
  - `drop_params=True` by default for cross-provider kwarg compatibility.                                                                                                                                            
                                                                                                                                                                                                                     
  ## Checklist before requesting a review                                                                                                                                                                            
  - [x] I have performed a self-review of my code                                                                                                                                                                    
  - [x] If it is a core feature, I have added thorough tests.
