### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The service exposes the web UI on `http://localhost:7861`.
 </tr>
 </table>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=icip-cas/PPTAgent&type=Date)](https://star-history.com/#icip-cas/PPTAgent&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=icip-cas/PPTAgent&type=Date)](https://star-history.dera.page/#icip-cas/PPTAgent&Date)
 
 ## Citation 🙏
 


### PR DESCRIPTION
The star history chart in the README no longer renders because the previous provider is blocked by GitHub stargazer API restrictions. This change points the chart image and its link at a working alternative (https://star-history.dera.page), so the project's star history is visible again. Please review and merge when convenient.