### PR TITLE
feat: add native MiniMax image generation to the text-to-image provider

### DIFF
--- a/deeppresenter/config.yaml.example
+++ b/deeppresenter/config.yaml.example
@@ -39,3 +39,15 @@ long_context_model:
 #   # sampling_parameters:
 #   #   response_format: "b64_json"
 #   #   extra_body: { "watermark": False }
+
+# # Native MiniMax image generation — no extra dependency required.
+# # `region` selects the regional endpoint: "global_en" (default) or "cn_zh".
+# # Set `base_url` instead to point at a custom deployment.
+# t2i_model:
+#   provider: "minimax"
+#   region: "global_en"
+#   model: "image-01"  # or "image-01-live"
+#   api_key: "your_key"
+#   # sampling_parameters:
+#   #   response_format: "base64"
+#   #   prompt_optimizer: true

--- a/deeppresenter/test/test_minimax_image.py
+++ b/deeppresenter/test/test_minimax_image.py
@@ -1,0 +1,275 @@
+import json
+
+import httpx
+import pytest
+
+from deeppresenter.utils.config import (
+    LLM,
+    MINIMAX_DEFAULT_IMAGE_MODEL,
+    MINIMAX_IMAGE_ENDPOINTS,
+    MINIMAX_IMAGE_PATH,
+    Endpoint,
+)
+
+IMAGE_URL = "https://example.com/generated.png"
+
+
+def _transport(body: dict, status_code: int = 200, requests: list | None = None):
+    """Build a mock transport that records requests and replays a fixed body."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if requests is not None:
+            requests.append(request)
+        return httpx.Response(status_code, json=body)
+
+    return httpx.MockTransport(handler)
+
+
+def _url_response(urls: list[str] | None = None) -> dict:
+    return {
+        "id": "trace-id",
+        "data": {"image_urls": urls if urls is not None else [IMAGE_URL]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+
+
+def _endpoint(requests: list, body: dict | None = None, **kwargs) -> Endpoint:
+    kwargs.setdefault("model", MINIMAX_DEFAULT_IMAGE_MODEL)
+    kwargs.setdefault("api_key", "test-key")
+    return Endpoint(
+        provider="minimax",
+        client_kwargs={
+            "transport": _transport(body or _url_response(), requests=requests)
+        },
+        **kwargs,
+    )
+
+
+def test_native_provider_skips_openai_client():
+    endpoint = Endpoint(provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL)
+    assert endpoint._client is None
+
+
+def test_regional_endpoints_are_resolved():
+    for region, url in MINIMAX_IMAGE_ENDPOINTS.items():
+        endpoint = Endpoint(
+            provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL, region=region
+        )
+        assert endpoint._minimax_image_url() == url
+        assert url.endswith(MINIMAX_IMAGE_PATH)
+
+
+def test_default_region_is_used_without_region():
+    endpoint = Endpoint(provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL)
+    assert endpoint._minimax_image_url() == MINIMAX_IMAGE_ENDPOINTS["global_en"]
+
+
+def test_unknown_region_is_rejected():
+    endpoint = Endpoint(
+        provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL, region="nowhere"
+    )
+    with pytest.raises(AssertionError):
+        endpoint._minimax_image_url()
+
+
+def test_base_url_overrides_region():
+    endpoint = Endpoint(
+        provider="minimax",
+        model=MINIMAX_DEFAULT_IMAGE_MODEL,
+        region="cn_zh",
+        base_url="https://gateway.example.com/",
+    )
+    assert (
+        endpoint._minimax_image_url()
+        == f"https://gateway.example.com{MINIMAX_IMAGE_PATH}"
+    )
+
+
+def test_base_url_with_operation_path_is_not_duplicated():
+    endpoint = Endpoint(
+        provider="minimax",
+        model=MINIMAX_DEFAULT_IMAGE_MODEL,
+        base_url=f"https://gateway.example.com{MINIMAX_IMAGE_PATH}",
+    )
+    assert (
+        endpoint._minimax_image_url()
+        == f"https://gateway.example.com{MINIMAX_IMAGE_PATH}"
+    )
+
+
+async def test_request_mapping_and_authorization():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests)
+
+    await endpoint._generate_image_minimax(
+        prompt="a red bicycle", width=1280, height=720, timeout=30
+    )
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.method == "POST"
+    assert str(request.url) == MINIMAX_IMAGE_ENDPOINTS["global_en"]
+    assert request.headers["Authorization"] == "Bearer test-key"
+    payload = json.loads(request.content)
+    assert payload["model"] == MINIMAX_DEFAULT_IMAGE_MODEL
+    assert payload["prompt"] == "a red bicycle"
+    assert payload["width"] == 1280
+    assert payload["height"] == 720
+    assert payload["response_format"] == "url"
+
+
+async def test_image_urls_are_parsed():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests)
+
+    response = await endpoint._generate_image_minimax(
+        prompt="a lighthouse", width=1024, height=1024, timeout=30
+    )
+
+    assert len(response.data) == 1
+    assert response.data[0].url == IMAGE_URL
+
+
+async def test_base64_response_format_is_parsed():
+    requests: list[httpx.Request] = []
+    body = {
+        "data": {"image_base64": ["QUJD"]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    endpoint = _endpoint(
+        requests, body=body, sampling_parameters={"response_format": "base64"}
+    )
+
+    response = await endpoint._generate_image_minimax(
+        prompt="a canyon", width=1024, height=1024, timeout=30
+    )
+
+    assert json.loads(requests[0].content)["response_format"] == "base64"
+    assert response.data[0].b64_json == "QUJD"
+
+
+async def test_unknown_response_format_is_rejected():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests, sampling_parameters={"response_format": "tiff"})
+
+    with pytest.raises(AssertionError):
+        await endpoint._generate_image_minimax(
+            prompt="a canyon", width=1024, height=1024, timeout=30
+        )
+    assert requests == []
+
+
+async def test_extra_sampling_parameters_are_forwarded():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(
+        requests, sampling_parameters={"prompt_optimizer": True, "seed": 7, "n": 2}
+    )
+
+    await endpoint._generate_image_minimax(
+        prompt="a forest", width=1024, height=1024, timeout=30
+    )
+
+    payload = json.loads(requests[0].content)
+    assert payload["prompt_optimizer"] is True
+    assert payload["seed"] == 7
+    assert payload["n"] == 2
+
+
+async def test_aspect_ratio_replaces_explicit_size():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests, sampling_parameters={"aspect_ratio": "16:9"})
+
+    await endpoint._generate_image_minimax(
+        prompt="a skyline", width=1280, height=720, timeout=30
+    )
+
+    payload = json.loads(requests[0].content)
+    assert payload["aspect_ratio"] == "16:9"
+    assert "width" not in payload
+    assert "height" not in payload
+
+
+async def test_default_model_is_used_for_blank_model():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests, model="")
+
+    await endpoint._generate_image_minimax(
+        prompt="a desert", width=1024, height=1024, timeout=30
+    )
+
+    assert json.loads(requests[0].content)["model"] == MINIMAX_DEFAULT_IMAGE_MODEL
+
+
+async def test_out_of_range_size_is_rejected():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests)
+
+    with pytest.raises(AssertionError):
+        await endpoint._generate_image_minimax(
+            prompt="a tiny icon", width=256, height=256, timeout=30
+        )
+    assert requests == []
+
+
+async def test_error_status_code_is_raised():
+    requests: list[httpx.Request] = []
+    body = {
+        "data": {},
+        "metadata": {"success_count": "0", "failed_count": "1"},
+        "base_resp": {"status_code": 1026, "status_msg": "sensitive content"},
+    }
+    endpoint = _endpoint(requests, body=body)
+
+    with pytest.raises(AssertionError, match="1026"):
+        await endpoint._generate_image_minimax(
+            prompt="a prompt", width=1024, height=1024, timeout=30
+        )
+
+
+async def test_empty_image_list_is_rejected():
+    requests: list[httpx.Request] = []
+    endpoint = _endpoint(requests, body=_url_response([]))
+
+    with pytest.raises(AssertionError):
+        await endpoint._generate_image_minimax(
+            prompt="a prompt", width=1024, height=1024, timeout=30
+        )
+
+
+async def test_chat_call_is_not_supported():
+    endpoint = Endpoint(provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL)
+    with pytest.raises(NotImplementedError):
+        await endpoint.call(
+            messages=[{"role": "user", "content": "hi"}], soft_response_parsing=False
+        )
+
+
+async def test_llm_generate_image_routes_to_native_provider():
+    requests: list[httpx.Request] = []
+    llm = LLM(
+        provider="minimax",
+        region="cn_zh",
+        model=MINIMAX_DEFAULT_IMAGE_MODEL,
+        api_key="test-key",
+        client_kwargs={"transport": _transport(_url_response(), requests=requests)},
+    )
+
+    response = await llm.generate_image(
+        prompt="a mountain", width=1280, height=720, retry_times=1
+    )
+
+    assert response.data[0].url == IMAGE_URL
+    assert str(requests[0].url) == MINIMAX_IMAGE_ENDPOINTS["cn_zh"]
+
+
+async def test_llm_validate_accepts_native_provider():
+    llm = LLM(provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL, api_key="test-key")
+    await llm.validate()
+
+
+async def test_llm_validate_requires_api_key():
+    llm = LLM(provider="minimax", model=MINIMAX_DEFAULT_IMAGE_MODEL)
+    with pytest.raises(AssertionError):
+        await llm.validate()

--- a/deeppresenter/utils/config.py
+++ b/deeppresenter/utils/config.py
@@ -1,14 +1,17 @@
 import asyncio
 import json
 import random
+import time
 from itertools import cycle, product
 from pathlib import Path
 from typing import Any, Literal
 
+import httpx
 import json_repair
 import yaml
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion
+from openai.types.image import Image
 from openai.types.images_response import ImagesResponse
 from pydantic import BaseModel, Field, PrivateAttr, ValidationError
 
@@ -70,15 +73,33 @@ def get_json_from_response(response: str) -> dict | list:
     return json_repair.loads(response)
 
 
+# Native MiniMax image generation. Every region exposes the same operation path,
+# so only the host differs between deployments.
+MINIMAX_IMAGE_PATH = "/v1/image_generation"
+MINIMAX_IMAGE_ENDPOINTS = {
+    "global_en": f"https://api.minimax.io{MINIMAX_IMAGE_PATH}",
+    "cn_zh": f"https://api.minimaxi.com{MINIMAX_IMAGE_PATH}",
+}
+MINIMAX_DEFAULT_IMAGE_REGION = "global_en"
+MINIMAX_DEFAULT_IMAGE_MODEL = "image-01"
+MINIMAX_IMAGE_RESPONSE_FORMATS = ("url", "base64")
+MINIMAX_IMAGE_SIZE_RANGE = (512, 2048)
+MINIMAX_IMAGE_PIXEL_MULTIPLE = 8
+
+
 class Endpoint(BaseModel):
     """LLM Endpoint Configuration"""
 
     base_url: str | None = Field(default=None, description="API base URL")
     model: str = Field(description="Model name")
     api_key: str | None = Field(default=None, description="API key")
-    provider: Literal["openai", "litellm"] = Field(
+    provider: Literal["openai", "litellm", "minimax"] = Field(
         default="openai",
-        description="Backend provider: 'openai' (default) or 'litellm'",
+        description="Backend provider: 'openai' (default), 'litellm' or 'minimax'",
+    )
+    region: str | None = Field(
+        default=None,
+        description="Regional endpoint key for native providers, e.g. 'global_en' or 'cn_zh'. Ignored when `base_url` is set",
     )
     client_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Client parameters"
@@ -89,7 +110,7 @@ class Endpoint(BaseModel):
     _client: AsyncOpenAI | None = PrivateAttr(default=None)
 
     def model_post_init(self, _) -> None:
-        if self.provider != "litellm":
+        if self.provider == "openai":
             self._client = AsyncOpenAI(
                 api_key=self.api_key,
                 base_url=self.base_url,
@@ -121,6 +142,76 @@ class Endpoint(BaseModel):
             kwargs["response_format"] = response_format
         return await litellm.acompletion(**kwargs)
 
+    def _minimax_image_url(self) -> str:
+        """Resolve the regional image generation URL of the native provider"""
+        if self.base_url:
+            base_url = self.base_url.rstrip("/")
+            if base_url.endswith(MINIMAX_IMAGE_PATH):
+                return base_url
+            return base_url + MINIMAX_IMAGE_PATH
+        region = self.region or MINIMAX_DEFAULT_IMAGE_REGION
+        assert region in MINIMAX_IMAGE_ENDPOINTS, (
+            f"Unknown region {region!r}, expected one of {sorted(MINIMAX_IMAGE_ENDPOINTS)}"
+        )
+        return MINIMAX_IMAGE_ENDPOINTS[region]
+
+    async def _generate_image_minimax(
+        self, prompt: str, width: int, height: int, timeout: int
+    ) -> ImagesResponse:
+        """Generate an image with the native image generation API"""
+        assert all(
+            MINIMAX_IMAGE_SIZE_RANGE[0] <= side <= MINIMAX_IMAGE_SIZE_RANGE[1]
+            and side % MINIMAX_IMAGE_PIXEL_MULTIPLE == 0
+            for side in (width, height)
+        ), (
+            f"Image width and height must be within {MINIMAX_IMAGE_SIZE_RANGE} and a "
+            f"multiple of {MINIMAX_IMAGE_PIXEL_MULTIPLE}, got {width}x{height}"
+        )
+        payload: dict[str, Any] = {
+            "model": self.model or MINIMAX_DEFAULT_IMAGE_MODEL,
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "response_format": MINIMAX_IMAGE_RESPONSE_FORMATS[0],
+            **self.sampling_parameters,
+        }
+        # an explicit aspect ratio takes priority over the size on the server side
+        if payload.get("aspect_ratio"):
+            payload.pop("width", None)
+            payload.pop("height", None)
+        response_format = payload["response_format"]
+        assert response_format in MINIMAX_IMAGE_RESPONSE_FORMATS, (
+            f"Unknown response_format {response_format!r}, expected one of "
+            f"{list(MINIMAX_IMAGE_RESPONSE_FORMATS)}"
+        )
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        async with httpx.AsyncClient(timeout=timeout, **self.client_kwargs) as client:
+            http_response = await client.post(
+                self._minimax_image_url(), headers=headers, json=payload
+            )
+        http_response.raise_for_status()
+        body = http_response.json()
+        base_resp = body.get("base_resp") or {}
+        status_code = int(base_resp.get("status_code", 0))
+        assert status_code == 0, (
+            f"Image generation failed with status {status_code}: "
+            f"{base_resp.get('status_msg', '')}"
+        )
+        data = body.get("data") or {}
+        if response_format == "base64":
+            images = [Image(b64_json=item) for item in data.get("image_base64") or []]
+        else:
+            images = [Image(url=item) for item in data.get("image_urls") or []]
+        assert len(images) >= 1, f"Expected at least an image response, got {body}"
+        metadata = body.get("metadata") or {}
+        debug(
+            f"Generated {metadata.get('success_count', len(images))} image(s) with "
+            f"{payload['model']}, {metadata.get('failed_count', 0)} failed"
+        )
+        return ImagesResponse(created=int(time.time()), data=images)
+
     async def call(
         self,
         messages: list[dict[str, Any]],
@@ -129,6 +220,11 @@ class Endpoint(BaseModel):
         tools: list[dict[str, Any]] | None = None,
     ) -> ChatCompletion:
         """Execute a chat or tool call using the endpoint client"""
+        if self.provider == "minimax":
+            raise NotImplementedError(
+                f"Provider '{self.provider}' only supports image generation, "
+                "configure it as `t2i_model`"
+            )
         if self.provider == "litellm":
             response = await self._call_litellm(messages, response_format, tools)
         elif tools is not None:
@@ -178,7 +274,11 @@ class LLM(BaseModel):
     api_key: str | None = Field(default=None, description="API key")
     provider: str = Field(
         default="openai",
-        description="Backend provider: 'openai' (default) or 'litellm'",
+        description="Backend provider: 'openai' (default), 'litellm' or 'minimax'",
+    )
+    region: str | None = Field(
+        default=None,
+        description="Regional endpoint key for native providers, e.g. 'global_en' or 'cn_zh'. Ignored when `base_url` is set",
     )
     identifier: str | None = Field(
         default=None,
@@ -232,6 +332,7 @@ class LLM(BaseModel):
                     model=self.model,
                     api_key=self.api_key,
                     provider=self.provider,
+                    region=self.region,
                     client_kwargs=self.client_kwargs,
                     sampling_parameters=self.sampling_parameters,
                 ),
@@ -332,6 +433,13 @@ class LLM(BaseModel):
                             ),
                             **endpoint.sampling_parameters,
                         )
+                    elif endpoint.provider == "minimax":
+                        response = await endpoint._generate_image_minimax(
+                            prompt=prompt,
+                            width=width,
+                            height=height,
+                            timeout=MCP_CALL_TIMEOUT // 5,
+                        )
                     else:
                         response = await endpoint._client.images.generate(
                             prompt=prompt,
@@ -358,6 +466,13 @@ class LLM(BaseModel):
 
     async def validate(self):
         endpoint = self._endpoints[0]
+        if endpoint.provider == "minimax":
+            # native image generation endpoints expose no model listing operation
+            assert endpoint.api_key, (
+                f"An API key is required for provider '{endpoint.provider}'"
+            )
+            endpoint._minimax_image_url()
+            return
         if endpoint.provider == "litellm":
             import litellm
 


### PR DESCRIPTION
Reason: The text-to-image tool could not call the native MiniMax image generation API, so its regional endpoints, request fields and response shape were unreachable.

## What changed

`deeppresenter/utils/config.py`

- Added a `minimax` value to `Endpoint.provider` so a `t2i_model` can be configured against the native `/v1/image_generation` operation without an extra dependency.
- Added a `region` field on `Endpoint` and `LLM` that selects the regional endpoint (`global_en` by default, or `cn_zh`). An explicit `base_url` still wins, so custom deployments keep working; the operation path is appended only when it is not already present.
- Added `Endpoint._generate_image_minimax`, which maps the tool arguments onto the documented request body (`model`, `prompt`, `width`, `height`, `response_format`) with `Bearer` authorization, and forwards any extra `sampling_parameters` such as `seed`, `n`, `prompt_optimizer` and `aspect_ratio`. Because an explicit aspect ratio takes priority over the size server-side, the explicit `width`/`height` are dropped when one is supplied, so the two never disagree silently.
- Parsed the response: `data.image_urls` for the default `url` format and `data.image_base64` for `base64`, both normalized into an `ImagesResponse` so the existing `image_generation` tool consumes them unchanged. A non-zero `base_resp.status_code` is raised with its `status_msg`, and `metadata.success_count` / `metadata.failed_count` are logged.
- Validated width and height against the documented `[512, 2048]` range and multiple-of-8 rule before sending the request, so an out-of-range size fails with a clear message instead of a generic parameter error.
- `model_post_init` now builds the OpenAI client only for the `openai` provider, instead of for everything that is not `litellm`, so the native provider does not construct an unused client. `LLM.validate` short-circuits for it as well, since the image endpoint exposes no model listing operation; it checks that an API key is present and that the endpoint resolves. A chat call against the image-only provider now raises a clear `NotImplementedError` rather than failing on a missing client.

`deeppresenter/config.yaml.example` — documented the new `t2i_model` block, including the region choices and the default model.

`deeppresenter/test/test_minimax_image.py` — new tests. They drive a real `httpx` client through a `MockTransport`, so the request body, headers, URL and response parsing are all exercised end to end without network access.

## Checks

- `python -m pytest deeppresenter/test/ -q` — 20 passed
- `ruff check deeppresenter/utils/config.py deeppresenter/test/test_minimax_image.py` — all checks passed
- `ruff check --select I deeppresenter/` and `ruff format --check` on the changed files — clean, matching the repo pre-commit hooks

The existing `openai` and `litellm` provider paths were re-checked by hand after the `model_post_init` change: the former still builds its client, the latter still does not.

## Notes

Existing behaviour is unchanged when `region` is unset and `provider` keeps its default. Image-to-image reference input is out of scope here; callers can already pass extra request fields through `sampling_parameters`.
