### PR TITLE
fix: check exact LOCAL_BASE_URL in uses_local_model (#247)

### DIFF
--- a/deeppresenter/cli/model.py
+++ b/deeppresenter/cli/model.py
@@ -166,7 +166,7 @@ def has_complete_model_config(existing_config: dict | None) -> bool:
 def uses_local_model(config: DeepPresenterConfig) -> bool:
     dumped = config.model_dump()
     return any(
-        "127.0.0.1" in str(dumped.get(key, {}).get("base_url", ""))
-        or "localhost" in str(dumped.get(key, {}).get("base_url", ""))
+        str(dumped.get(key, {}).get("base_url", "")).strip().rstrip("/")
+        == LOCAL_BASE_URL.rstrip("/")
         for key in REQUIRED_LLM_KEYS
     )


### PR DESCRIPTION
Fixes #247

**Problem**
`uses_local_model()` in `deeppresenter/cli/model.py:166-172` used naive substring check (`"localhost" in base_url or "127.0.0.1" in base_url`), so any gateway on `localhost` (e.g. `http://localhost:8317/v1`) incorrectly triggered local `DeepPresenter-9B` via `llama-server` and failed silently (`--log-disable`).

**Fix**
Check exact `LOCAL_BASE_URL` (`http://127.0.0.1:7811/v1` from `deeppresenter/cli/common.py:18`) via normalized exact match:
```python
return any(str(dumped.get(key, {}).get("base_url","")).strip().rstrip("/") == LOCAL_BASE_URL.rstrip("/") for key in REQUIRED_LLM_KEYS)
```
Imported `LOCAL_BASE_URL` already available in `model.py:15-21`.

**Verification (folder-local, no global installs)**
- Clone to `C:\\Users\\Azelf\\AppData\\Local\\Temp\\opencode\\PPTAgent-fix`, `python -m venv .venv`, `.venv\\Scripts\\python -m pip install -e . --no-deps` + minimal deps (`pydantic`, `openai`, `PyYAML`, `json-repair`, `rich`, `colorlog`, `typer`) for Windows bypass of `deeppresenter/__init__.py:9` posix assert (patched locally for verification only)
- **Before fix** (with `file_path` default patched for repro):
  ```
  .venv\Scripts\python -c "from deeppresenter.utils.config import DeepPresenterConfig; from deeppresenter.cli.model import uses_local_model; cfg=DeepPresenterConfig.model_validate({...8317...}); print(uses_local_model(cfg))"
  -> True (bug)
  ```
- **After fix**:
  ```
  .venv\Scripts\python -c "... localhost:8317 ..."
  -> False
  .venv\Scripts\python -c "... 127.0.0.1:7811/v1 ..."
  -> True
  .venv\Scripts\python -c "... 127.0.0.1:7811/v1/ (trailing slash) ..."
  -> True
  .venv\Scripts\python -c "... https://api.openai.com/v1 ..."
  -> False
  ```
- `pytest pptagent/test --collect-only` : no `tests/` at repo root; `pptagent/test` collection requires full deps (`bs4` etc) not installed folder-locally, but import verification passes. `python -m pytest pptagent/test -k "not llm and not live" --collect-only` attempted folder-locally (see logs).

No global pip, no Docker, branch `AquaticAzelf:fix/local-model-gateway-247` pushed via API.
